### PR TITLE
Added tests to validate JWT Auth compatibility with OAuth2

### DIFF
--- a/rest_framework_jwt/runtests/settings.py
+++ b/rest_framework_jwt/runtests/settings.py
@@ -23,6 +23,17 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 )
 
+# OAuth2 is optional and won't work if there is no provider & oauth2
+try:
+    import provider
+except ImportError:
+    pass
+else:
+    INSTALLED_APPS += (
+        'provider',
+        'provider.oauth2',
+    )
+
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps = -rrequirements.txt
+	   django-oauth2-provider
+commands = {envpython} rest_framework_jwt/runtests/runtests.py
+


### PR DESCRIPTION
I've added the tests to validate the compatibility problem between JWT Auth and OAuth2, which I commented on the issue https://github.com/GetBlimp/django-rest-framework-jwt/issues/3.

I have also used `Tox` to make it possible to run the tests with the extra requirement of `django-oauth2-provider` without altering the base requirements of the package.
