### PR TITLE
Custom User model compatibility

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -8,7 +8,7 @@ def jwt_payload_handler(user):
     return {
         'user_id': user.id,
         'email': user.email,
-        'username': user.username,
+        'username': user.get_username(),
         'exp': datetime.datetime.utcnow() + api_settings.JWT_EXPIRATION_DELTA
     }
 


### PR DESCRIPTION
From the docs: "Since the User model can be swapped out, you should use this method instead of referencing the username attribute directly."
