### PR TITLE
Custom User Models + Tests

### DIFF
--- a/rest_framework_jwt/runtests/models.py
+++ b/rest_framework_jwt/runtests/models.py
@@ -1,0 +1,5 @@
+from django.contrib.auth.models import User
+
+
+class CustomUser(User):
+    USERNAME_FIELD = 'email'

--- a/rest_framework_jwt/runtests/settings.py
+++ b/rest_framework_jwt/runtests/settings.py
@@ -21,6 +21,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework_jwt.runtests',
 )
 
 # OAuth2 is optional and won't work if there is no provider & oauth2

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -17,13 +17,16 @@ class JSONWebTokenSerializer(serializers.Serializer):
     Returns a JSON Web Token that can be used to authenticate later calls.
     """
 
-    username_field = get_user_model().USERNAME_FIELD
     password = serializers.CharField(write_only=True)
 
     def __init__(self, *args, **kwargs):
         """Dynamically add the USERNAME_FIELD to self.fields."""
         super(JSONWebTokenSerializer, self).__init__(*args, **kwargs)
         self.fields[self.username_field] = serializers.CharField()
+
+    @property
+    def username_field(self):
+        return get_user_model().USERNAME_FIELD
 
     def validate(self, attrs):
         credentials = {self.username_field: attrs.get(self.username_field),


### PR DESCRIPTION
Added some tests, on top of the pull request https://github.com/GetBlimp/django-rest-framework-jwt/pull/18 from @cborgolte . I have a custom user model with USERNAME_FIELD = 'email' (well not that custom but didn't feel like making one from scratch).

One change I made was remove `username_field` as a class variable from JSONWebTokenSerializer, as it made testing a bit harder (get_user_model() would only be evaluated on module import, and you'd have to do manually reload the module after changing settings.AUTH_USER_MODEL) 
