### PR TITLE
User ID property in payloads (and tests)

### DIFF
--- a/rest_framework_jwt/tests/test_utils.py
+++ b/rest_framework_jwt/tests/test_utils.py
@@ -16,7 +16,7 @@ class UtilsTests(TestCase):
         payload = utils.jwt_payload_handler(self.user)
 
         self.assertTrue(isinstance(payload, dict))
-        self.assertEqual(payload['user_id'], self.user.id)
+        self.assertEqual(payload['user_id'], self.user.pk)
         self.assertEqual(payload['email'], self.email)
         self.assertEqual(payload['username'], self.username)
         self.assertTrue('exp' in payload)

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -6,7 +6,7 @@ from rest_framework_jwt.settings import api_settings
 
 def jwt_payload_handler(user):
     return {
-        'user_id': user.id,
+        'user_id': user.pk,
         'email': user.email,
         'username': user.get_username(),
         'exp': datetime.datetime.utcnow() + api_settings.JWT_EXPIRATION_DELTA


### PR DESCRIPTION
Using the general built-in 'pk' property of Django's User model instead of the property 'id' (as described in issue #25).
