### PR TITLE
covert user.pk to str, support mongoengine

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -22,7 +22,7 @@ def jwt_payload_handler(user):
         username = user.username
 
     return {
-        'user_id': user.pk,
+        'user_id': str(user.pk),
         'email': user.email,
         'username': username,
         'exp': datetime.utcnow() + api_settings.JWT_EXPIRATION_DELTA


### PR DESCRIPTION
if django db backends user mongoengine, coverting `user.pk` to str can work well.
