### PR TITLE
Changed potentially misleading error message

### DIFF
--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -68,7 +68,10 @@ class JSONWebTokenSerializer(Serializer):
                 msg = 'Unable to login with provided credentials.'
                 raise serializers.ValidationError(msg)
         else:
-            msg = 'Must include "username" and "password"'
+            msg = 'Must include "{0}" and "{1}"'.format(
+                self.username_field,
+                'password'
+                )
             raise serializers.ValidationError(msg)
 
 

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -68,10 +68,8 @@ class JSONWebTokenSerializer(Serializer):
                 msg = 'Unable to login with provided credentials.'
                 raise serializers.ValidationError(msg)
         else:
-            msg = 'Must include "{0}" and "{1}"'.format(
-                self.username_field,
-                'password'
-            )
+            msg = 'Must include "{0}" and "password"'.format(
+                self.username_field)
             raise serializers.ValidationError(msg)
 
 

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -71,7 +71,7 @@ class JSONWebTokenSerializer(Serializer):
             msg = 'Must include "{0}" and "{1}"'.format(
                 self.username_field,
                 'password'
-                )
+            )
             raise serializers.ValidationError(msg)
 
 


### PR DESCRIPTION
If a custom user model uses a different name for the 'username' field, the error message thrown by JSONWebTokenSerializer.validate in case of a missing field is incorrect.