### PR TITLE
Add user=None Arguments To Encode and Decode Handlers

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -37,7 +37,7 @@ def jwt_get_user_id_from_payload_handler(payload):
     return user_id
 
 
-def jwt_encode_handler(payload):
+def jwt_encode_handler(payload, user=None):
     return jwt.encode(
         payload,
         api_settings.JWT_SECRET_KEY,
@@ -45,7 +45,7 @@ def jwt_encode_handler(payload):
     ).decode('utf-8')
 
 
-def jwt_decode_handler(token):
+def jwt_decode_handler(token, user=None):
     return jwt.decode(
         token,
         api_settings.JWT_SECRET_KEY,


### PR DESCRIPTION
This PR makes it possible to access a `user` inside  `jwt_encode_handler()` and `jwt_decode_handler()` --> the encode/decode handlers now have signatures like:
```python
def jwt_encode_handler(payload, user=None):
```

I've passed the appropriate `user` object to all instances of `jwt_encode_handler()` in the code base.   

Someone who wanted to take advantage of a `user` object in `jwt_decode_handler()`, however, would need to override `RefreshJSONWebTokenSerializer.validate()` and `JSONWebTokenAuthentication.authenticate()` with logic that would retrieve a user before calling `jwt_decode_handler()`.  I've abstracted functionality in `JSONWebTokenAuthentication` and `RefreshJSONWebTokenSerializer`  to make such overrides easier.

Related issue: #63 