### PR TITLE
Support HyperlinkedModelSerializer

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -56,7 +56,7 @@ def jwt_decode_handler(token):
     )
 
 
-def jwt_response_payload_handler(token, user=None):
+def jwt_response_payload_handler(token, user=None, request=None):
     """
     Returns the response data for both the login and refresh views.
     Override to return a custom response such as including the

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -30,7 +30,7 @@ class ObtainJSONWebToken(APIView):
         if serializer.is_valid():
             user = serializer.object.get('user') or request.user
             token = serializer.object.get('token')
-            response_data = jwt_response_payload_handler(token, user)
+            response_data = jwt_response_payload_handler(token, user, request)
 
             return Response(response_data)
 
@@ -58,7 +58,7 @@ class RefreshJSONWebToken(APIView):
         if serializer.is_valid():
             user = serializer.object.get('user') or request.user
             token = serializer.object.get('token')
-            response_data = jwt_response_payload_handler(token, user)
+            response_data = jwt_response_payload_handler(token, user, request)
 
             return Response(response_data)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-def jwt_response_payload_handler(token, user=None):
+def jwt_response_payload_handler(token, user=None, request=None):
     """
     Returns the response data for both the login and refresh views.
     Override to return a custom response such as including the


### PR DESCRIPTION
By providing the ``request`` object to the jwt_response_payload_handler we can use ``HyperlinkedModelSerializer`` for a "UserSerializer" and prevent the following errror:

```
AssertionError: `HyperlinkedIdentityField` requires the request in the serializer context. Add `context={'request': request}` when instantiating the serializer.
```