### PR TITLE
Added a JWT verification view

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,21 @@ Refresh with tokens can be repeated (token1 -> token2 -> token3), but this chain
 
 A typical use case might be a web app where you'd like to keep the user "logged in" the site without having to re-enter their password, or get kicked out by surprise before their token expired. Imagine they had a 1-hour token and are just at the last minute while they're still doing something. With mobile you could perhaps store the username/password to get a new token, but this is not a great idea in a browser. Each time the user loads the page, you can check if there is an existing non-expired token and if it's close to being expired, refresh it to extend their session. In other words, if a user is actively using your site, they can keep their "session" alive.
 
+## Verify Token
+
+In some microservice architectures, authentication is handled by a single service. Other services delegate the responsibility of confirming that a user is logged in to this authentication service. This usually means that a service will pass a JWT received from the user to the authentication service, and wait for a confirmation that the JWT is valid before returning protected resources to the user.
+
+This setup is supported in this package using a verification endpoint. Add the following URL pattern:
+```python
+    url(r'^api-token-verify/', 'rest_framework_jwt.views.verify_jwt_token'),
+```
+
+Passing a token to the verification endpoint will return a 200 response and the token if it is valid. Otherwise, it will return a 400 Bad Request as well as an error identifying why the token was invalid.
+
+```bash
+$ curl -X POST -H "Content-Type: application/json" -d '{"token":"<EXISTING_TOKEN>"}' http://localhost:8000/api-token-verify/
+```
+
 ## Additional Settings
 There are some additional settings that you can override similar to how you'd do it with Django REST framework itself. Here are all the available defaults.
 

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -81,16 +81,17 @@ class JSONWebTokenSerializer(Serializer):
             raise serializers.ValidationError(msg)
 
 
-class RefreshJSONWebTokenSerializer(Serializer):
+class VerificationBaseSerializer(Serializer):
     """
-    Check an access token
+    Abstract serializer used for verifying and refreshing JWTs.
     """
     token = serializers.CharField()
 
     def validate(self, attrs):
-        User = utils.get_user_model()
-        token = attrs['token']
+        msg = _('Please define a validate method.')
+        raise NotImplementedError(msg)
 
+    def _check_payload(self, token):
         # Check payload valid (based off of JSONWebTokenAuthentication,
         # may want to refactor)
         try:
@@ -102,6 +103,10 @@ class RefreshJSONWebTokenSerializer(Serializer):
             msg = _('Error decoding signature.')
             raise serializers.ValidationError(msg)
 
+        return payload
+
+    def _check_user(self, payload):
+        User = utils.get_user_model()
         # Make sure user exists (may want to refactor this)
         try:
             user_id = jwt_get_user_id_from_payload(payload)
@@ -115,6 +120,38 @@ class RefreshJSONWebTokenSerializer(Serializer):
             msg = _("User doesn't exist.")
             raise serializers.ValidationError(msg)
 
+        return user
+
+
+class VerifyJSONWebTokenSerializer(VerificationBaseSerializer):
+    """
+    Check the veracity of an access token.
+    """
+
+    def validate(self, attrs):
+        token = attrs['token']
+
+        payload = self._check_payload(token=token)
+        user = self._check_user(payload=payload)
+
+        new_payload = jwt_payload_handler(user)
+
+        return {
+            'token': jwt_encode_handler(new_payload),
+            'user': user
+        }
+
+
+class RefreshJSONWebTokenSerializer(VerificationBaseSerializer):
+    """
+    Refresh an access token.
+    """
+
+    def validate(self, attrs):
+        token = attrs['token']
+
+        payload = self._check_payload(token=token)
+        user = self._check_user(payload=payload)
         # Get and check 'orig_iat'
         orig_iat = payload.get('orig_iat')
 

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -88,7 +88,7 @@ class VerificationBaseSerializer(Serializer):
     token = serializers.CharField()
 
     def validate(self, attrs):
-        msg = _('Please define a validate method.')
+        msg = 'Please define a validate method.'
         raise NotImplementedError(msg)
 
     def _check_payload(self, token):

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -6,7 +6,10 @@ from rest_framework.response import Response
 
 from rest_framework_jwt.settings import api_settings
 
-from .serializers import JSONWebTokenSerializer, RefreshJSONWebTokenSerializer
+from .serializers import (
+    JSONWebTokenSerializer, RefreshJSONWebTokenSerializer,
+    VerifyJSONWebTokenSerializer
+)
 
 jwt_response_payload_handler = api_settings.JWT_RESPONSE_PAYLOAD_HANDLER
 
@@ -37,20 +40,17 @@ class ObtainJSONWebToken(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class RefreshJSONWebToken(APIView):
+class VerifyJSONWebToken(APIView):
     """
-    API View that returns a refreshed token (with new expiration) based on
-    existing token
-
-    If 'orig_iat' field (original issued-at-time) is found, will first check
-    if it's within expiration window, then copy it to the new token
+    API View that checks the veracity of a token, returning the token if it
+    is valid.
     """
     throttle_classes = ()
     permission_classes = ()
     authentication_classes = ()
     parser_classes = (parsers.FormParser, parsers.JSONParser,)
     renderer_classes = (renderers.JSONRenderer,)
-    serializer_class = RefreshJSONWebTokenSerializer
+    serializer_class = VerifyJSONWebTokenSerializer
 
     def post(self, request):
         serializer = self.serializer_class(data=request.DATA)
@@ -65,5 +65,17 @@ class RefreshJSONWebToken(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+class RefreshJSONWebToken(VerifyJSONWebToken):
+    """
+    API View that returns a refreshed token (with new expiration) based on
+    existing token
+
+    If 'orig_iat' field (original issued-at-time) is found, will first check
+    if it's within expiration window, then copy it to the new token
+    """
+    serializer_class = RefreshJSONWebTokenSerializer
+
+
 obtain_jwt_token = ObtainJSONWebToken.as_view()
 refresh_jwt_token = RefreshJSONWebToken.as_view()
+verify_jwt_token = VerifyJSONWebToken.as_view()

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -14,7 +14,7 @@ from .serializers import (
 jwt_response_payload_handler = api_settings.JWT_RESPONSE_PAYLOAD_HANDLER
 
 
-class JWTAPIView(APIView):
+class JSONWebTokenAPIView(APIView):
     """
     Base API View that various JWT interactions inherit from.
     """
@@ -37,7 +37,7 @@ class JWTAPIView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class ObtainJSONWebToken(JWTAPIView):
+class ObtainJSONWebToken(JSONWebTokenAPIView):
     """
     API View that receives a POST with a user's username and password.
 
@@ -46,7 +46,7 @@ class ObtainJSONWebToken(JWTAPIView):
     serializer_class = JSONWebTokenSerializer
 
 
-class VerifyJSONWebToken(JWTAPIView):
+class VerifyJSONWebToken(JSONWebTokenAPIView):
     """
     API View that checks the veracity of a token, returning the token if it
     is valid.
@@ -54,7 +54,7 @@ class VerifyJSONWebToken(JWTAPIView):
     serializer_class = VerifyJSONWebTokenSerializer
 
 
-class RefreshJSONWebToken(JWTAPIView):
+class RefreshJSONWebToken(JSONWebTokenAPIView):
     """
     API View that returns a refreshed token (with new expiration) based on
     existing token


### PR DESCRIPTION
This PR adds a verification view: `verify_jwt_token`, which checks if a JWT POSTed to it is valid and that the user exists. 

Much of the functionality is the same as the existing `refresh` view and serializer. I abstracted out the majority of the shared serializer logic to maximise DRYness. There are several other ways this could be implemented, however.

I added tests for the new view and moved a test which was more relevant to this functionality from the refresh view tests.

Suggestions for improvements welcome! If the serializer implementation is ok, it could probably use some unit tests.