### PR TITLE
Allow setting audience and issuer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -127,6 +127,8 @@ JWT_AUTH = {
     'JWT_VERIFY_EXPIRATION': True,
     'JWT_LEEWAY': 0,
     'JWT_EXPIRATION_DELTA': datetime.timedelta(seconds=300),
+    'JWT_AUDIENCE': None,
+    'JWT_ISSUER': None,
 
     'JWT_ALLOW_REFRESH': False,
     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
@@ -181,6 +183,16 @@ Default is `0` seconds.
 This is an instance of Python's `datetime.timedelta`. This will be added to `datetime.utcnow()` to set the expiration time.
 
 Default is `datetime.timedelta(seconds=300)`(5 minutes).
+
+### JWT_AUDIENCE
+This is a string that will be checked against the `aud` field of the token, if present.
+
+Default is `None`(fail if `aud` present on JWT).
+
+### JWT_ISSUER
+This is a string that will be checked against the `iss` field of the token.
+
+Default is `None`(do not check `iss` on JWT).
 
 ### JWT_ALLOW_REFRESH
 Enable token refresh functionality. Token issued from `rest_framework_jwt.views.obtain_jwt_token` will have an `orig_iat` field. Default is `False`

--- a/rest_framework_jwt/settings.py
+++ b/rest_framework_jwt/settings.py
@@ -33,6 +33,8 @@ DEFAULTS = {
     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
+
+    'JWT_AUDIENCE': None,
 }
 
 # List of settings that may be in string import notation.

--- a/rest_framework_jwt/settings.py
+++ b/rest_framework_jwt/settings.py
@@ -28,13 +28,13 @@ DEFAULTS = {
     'JWT_VERIFY_EXPIRATION': True,
     'JWT_LEEWAY': 0,
     'JWT_EXPIRATION_DELTA': datetime.timedelta(seconds=300),
+    'JWT_AUDIENCE': None,
+    'JWT_ISSUER': None,
 
     'JWT_ALLOW_REFRESH': False,
     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
-
-    'JWT_AUDIENCE': None,
 }
 
 # List of settings that may be in string import notation.

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -53,7 +53,8 @@ def jwt_decode_handler(token):
         api_settings.JWT_VERIFY,
         verify_expiration=api_settings.JWT_VERIFY_EXPIRATION,
         leeway=api_settings.JWT_LEEWAY,
-        audience=api_settings.JWT_AUDIENCE
+        audience=api_settings.JWT_AUDIENCE,
+        issuer=api_settings.JWT_ISSUER
     )
 
 

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -52,7 +52,8 @@ def jwt_decode_handler(token):
         api_settings.JWT_SECRET_KEY,
         api_settings.JWT_VERIFY,
         verify_expiration=api_settings.JWT_VERIFY_EXPIRATION,
-        leeway=api_settings.JWT_LEEWAY
+        leeway=api_settings.JWT_LEEWAY,
+        audience=api_settings.JWT_AUDIENCE
     )
 
 


### PR DESCRIPTION
Right now there is no way to pass in the audience to validate which causes the following to fail:
https://github.com/jpadilla/pyjwt/blob/5f9bc05803508b844d3fd9c61cd5210af06eecd8/jwt/api.py#L169

closes #79 
closes #81 