### PR TITLE
Allow subclassing JSONWebTokenAuthentication

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -219,6 +219,17 @@ Another common value used for tokens and Authorization headers is `Bearer`.
 
 Default is `JWT`.
 
+## Extending `JSONWebTokenAuthentication`
+
+Right now `JSONWebTokenAuthentication` assumes that the JWT will come in the header. The JWT spec does not require this (see: [Making a service Call](https://developer.atlassian.com/static/connect/docs/concepts/authentication.html)). For example, the JWT may come in the querystring. The ability to send the JWT in the querystring is needed in cases where the user cannot set the header (for example the src element in HTML).
+
+To achieve this functionality, the user might write a custom `Authentication`:
+```python
+class JSONWebTokenAuthenticationQS(BaseJSONWebTokenAuthentication):
+    def get_jwt_value(self, request):
+         return request.QUERY_PARAMS.get('jwt')
+```
+It is recommended to use `BaseJSONWebTokenAuthentication`, a new base class with no logic around parsing the HTTP headers.
 
 [jwt-auth-spec]: http://tools.ietf.org/html/draft-ietf-oauth-json-web-token
 [drf]: http://django-rest-framework.org/

--- a/rest_framework_jwt/authentication.py
+++ b/rest_framework_jwt/authentication.py
@@ -13,10 +13,56 @@ jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
 jwt_get_user_id_from_payload = api_settings.JWT_PAYLOAD_GET_USER_ID_HANDLER
 
 
-class JSONWebTokenAuthentication(BaseAuthentication):
+class JSONWebTokenAuthenticationBase(BaseAuthentication):
     """
     Token based authentication using the JSON Web Token standard.
+    """
 
+    def authenticate(self, request):
+        """
+        Returns a two-tuple of `User` and token if a valid signature has been
+        supplied using JWT-based authentication.  Otherwise returns `None`.
+        """
+        jwt_value = self.get_jwt_value(request)
+        if jwt_value is None:
+            return None
+
+        try:
+            payload = jwt_decode_handler(jwt_value)
+        except jwt.ExpiredSignature:
+            msg = _('Signature has expired.')
+            raise exceptions.AuthenticationFailed(msg)
+        except jwt.DecodeError:
+            msg = _('Error decoding signature.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        user = self.authenticate_credentials(payload)
+
+        return (user, jwt_value)
+
+    def authenticate_credentials(self, payload):
+        """
+        Returns an active user that matches the payload's user id and email.
+        """
+        User = utils.get_user_model()
+
+        user_id = jwt_get_user_id_from_payload(payload)
+
+        if user_id is not None:
+            try:
+                user = User.objects.get(pk=user_id, is_active=True)
+            except User.DoesNotExist:
+                msg = _('Invalid signature.')
+                raise exceptions.AuthenticationFailed(msg)
+        else:
+            msg = _('Invalid payload.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        return user
+
+
+class JSONWebTokenAuthentication(JSONWebTokenAuthenticationBase):
+    """
     Clients should authenticate by passing the token key in the "Authorization"
     HTTP header, prepended with the string specified in the setting
     `JWT_AUTH_HEADER_PREFIX`. For example:
@@ -25,11 +71,7 @@ class JSONWebTokenAuthentication(BaseAuthentication):
     """
     www_authenticate_realm = 'api'
 
-    def authenticate(self, request):
-        """
-        Returns a two-tuple of `User` and token if a valid signature has been
-        supplied using JWT-based authentication.  Otherwise returns `None`.
-        """
+    def get_jwt_value(self, request):
         auth = get_authorization_header(request).split()
         auth_header_prefix = api_settings.JWT_AUTH_HEADER_PREFIX.lower()
 
@@ -44,38 +86,7 @@ class JSONWebTokenAuthentication(BaseAuthentication):
                     'should not contain spaces.')
             raise exceptions.AuthenticationFailed(msg)
 
-        try:
-            payload = jwt_decode_handler(auth[1])
-        except jwt.ExpiredSignature:
-            msg = _('Signature has expired.')
-            raise exceptions.AuthenticationFailed(msg)
-        except jwt.DecodeError:
-            msg = _('Error decoding signature.')
-            raise exceptions.AuthenticationFailed(msg)
-
-        user = self.authenticate_credentials(payload)
-
-        return (user, auth[1])
-
-    def authenticate_credentials(self, payload):
-        """
-        Returns an active user that matches the payload's user id and email.
-        """
-        User = utils.get_user_model()
-
-        try:
-            user_id = jwt_get_user_id_from_payload(payload)
-
-            if user_id is not None:
-                user = User.objects.get(pk=user_id, is_active=True)
-            else:
-                msg = _('Invalid payload.')
-                raise exceptions.AuthenticationFailed(msg)
-        except User.DoesNotExist:
-            msg = _('Invalid signature.')
-            raise exceptions.AuthenticationFailed(msg)
-
-        return user
+        return auth[1]
 
     def authenticate_header(self, request):
         """

--- a/rest_framework_jwt/authentication.py
+++ b/rest_framework_jwt/authentication.py
@@ -13,7 +13,7 @@ jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
 jwt_get_user_id_from_payload = api_settings.JWT_PAYLOAD_GET_USER_ID_HANDLER
 
 
-class JSONWebTokenAuthenticationBase(BaseAuthentication):
+class BaseJSONWebTokenAuthentication(BaseAuthentication):
     """
     Token based authentication using the JSON Web Token standard.
     """
@@ -61,7 +61,7 @@ class JSONWebTokenAuthenticationBase(BaseAuthentication):
         return user
 
 
-class JSONWebTokenAuthentication(JSONWebTokenAuthenticationBase):
+class JSONWebTokenAuthentication(BaseJSONWebTokenAuthentication):
     """
     Clients should authenticate by passing the token key in the "Authorization"
     HTTP header, prepended with the string specified in the setting


### PR DESCRIPTION
Right now `JSONWebTokenAuthentication` assumes that the jwt will come in the header. The JWT does not require this (see [Making a service Call](https://developer.atlassian.com/static/connect/docs/concepts/authentication.html)). The jwt may come in the querystring. The ability to send the jwt in the querystring is needed in cases where the user cannot set the header (for example the src element in HTML).

This refactoring make it easy to change the source for the JWT. For example:
```python
class JSONWebTokenAuthenticationCreateQS(JSONWebTokenAuthenticationBase):
    def get_jwt_value(self, request): 
         return request.QUERY_PARAMS.get('jwt')
```