### PR TITLE
Use only ASCII characters in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Requirements
 Installation
 ------------
 
-Install using ``pip``\ …
+Install using ``pip``\ ...
 
 .. code:: bash
 


### PR DESCRIPTION
During installation, there's an UnicodeDecodeError because in README.rst there are non-ASCII characters 