### PR TITLE
propagate request arg in all the doc strings

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -218,7 +218,7 @@ Defaults to return the JWT token.
 
 Example:
 ```
-def jwt_response_payload_handler(token, user=None):
+def jwt_response_payload_handler(token, user=None, request=None):
     return {
         'token': token,
         'user': UserSerializer(user).data

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -67,7 +67,7 @@ def jwt_response_payload_handler(token, user=None, request=None):
 
     Example:
 
-    def jwt_response_payload_handler(token, user=None):
+    def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
             'user': UserSerializer(user).data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,7 +53,7 @@ class UtilsTests(TestCase):
     def test_jwt_response_payload(self):
         payload = utils.jwt_payload_handler(self.user)
         token = utils.jwt_encode_handler(payload)
-        response_data = utils.jwt_response_payload_handler(token, self.user)
+        response_data = utils.jwt_response_payload_handler(token)
 
         self.assertEqual(response_data, dict(token=token))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,7 @@ def jwt_response_payload_handler(token, user=None, request=None):
 
     Example:
 
-    def jwt_response_payload_handler(token, user=None):
+    def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
             'user': UserSerializer(user).data


### PR DESCRIPTION
this change was introduced in 238e14fee97403ba509022e12950a87fe9b8e8d2
but only in the code and tests, documentation was left behind