### PR TITLE
add python 3.2 to tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-django{1.6,1.7,1.8}-drf{2.4.3,2.4.4,3.0.0,3.1.0}
+       {py27,py32,py33,py34}-django{1.6,1.7,1.8}-drf{2.4.3,2.4.4,3.0.0,3.1.0}
 
 [testenv]
 commands = ./runtests.py --fast {posargs}


### PR DESCRIPTION
as support is claimed on docs (and works).