### PR TITLE
2 seconds is an eternity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pytest-django==2.6
 pytest==2.5.2
 pytest-cov==1.6
 flake8==2.2.2
+freezegun==0.3.2
 
 # Optional packages
 django-oauth-plus>=2.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
        py27-django1.6-drf{2.4.3,2.4.4,3.0.0,3.1.0}: django-oauth2-provider==0.2.6.1
        pytest-django==2.8.0
        py27-django{1.6,1.7,1.8}-drf3.1.0: djangorestframework-oauth==1.0.1
+       freezegun==0.3.2
 
 [testenv:py27-flake8]
 commands = ./runtests.py --lintonly


### PR DESCRIPTION
Avoid `time.sleep(2)` by mocking datetime module.