### PR TITLE
Refresh from expired token

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pytest-django==2.6
 pytest==2.5.2
 pytest-cov==1.6
 flake8==2.2.2
+freezegun==0.3.2
 
 # Optional packages
 django-oauth-plus>=2.2.1

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -91,11 +91,11 @@ class VerificationBaseSerializer(Serializer):
         msg = 'Please define a validate method.'
         raise NotImplementedError(msg)
 
-    def _check_payload(self, token):
+    def _check_payload(self, token, verify_exp=None):
         # Check payload valid (based off of JSONWebTokenAuthentication,
         # may want to refactor)
         try:
-            payload = jwt_decode_handler(token)
+            payload = jwt_decode_handler(token, verify_exp=verify_exp)
         except jwt.ExpiredSignature:
             msg = _('Signature has expired.')
             raise serializers.ValidationError(msg)
@@ -150,7 +150,7 @@ class RefreshJSONWebTokenSerializer(VerificationBaseSerializer):
     def validate(self, attrs):
         token = attrs['token']
 
-        payload = self._check_payload(token=token)
+        payload = self._check_payload(token=token, verify_exp=False)
         user = self._check_user(payload=payload)
         # Get and check 'orig_iat'
         orig_iat = payload.get('orig_iat')

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -46,9 +46,10 @@ def jwt_encode_handler(payload):
     ).decode('utf-8')
 
 
-def jwt_decode_handler(token):
+def jwt_decode_handler(token, verify_exp=None):
     options = {
-        'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
+        'verify_exp': (api_settings.JWT_VERIFY_EXPIRATION if
+                       verify_exp is None else verify_exp),
     }
 
     return jwt.decode(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -336,6 +336,36 @@ class RefreshJSONWebTokenTests(TokenTestCase):
         self.assertEquals(new_token_decoded['orig_iat'], orig_iat)
         self.assertGreater(new_token_decoded['exp'], orig_token_decoded['exp'])
 
+    def test_refresh_jwt_with_expired_token(self):
+        """
+        Test getting a refreshed token from original expired token works
+        """
+        client = APIClient(enforce_csrf_checks=True)
+
+        with freeze_time('2015-01-01 00:00:01'):
+            orig_token = self.get_token()
+            orig_token_decoded = utils.jwt_decode_handler(orig_token)
+
+            expected_orig_iat = timegm(datetime.utcnow().utctimetuple())
+
+            # Make sure 'orig_iat' exists and is the current time (give some slack)
+            orig_iat = orig_token_decoded['orig_iat']
+            self.assertLessEqual(orig_iat - expected_orig_iat, 1)
+
+            with freeze_time('2015-01-01 00:06:01'):
+
+                # Now try to get a refreshed token
+                response = client.post('/auth-token-refresh/', {'token': orig_token},
+                                       format='json')
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            new_token = response.data['token']
+            new_token_decoded = utils.jwt_decode_handler(new_token)
+
+        # Make sure 'orig_iat' on the new token is same as original
+        self.assertEquals(new_token_decoded['orig_iat'], orig_iat)
+        self.assertGreater(new_token_decoded['exp'], orig_token_decoded['exp'])
+
     def test_refresh_jwt_after_refresh_expiration(self):
         """
         Test that token can't be refreshed after token refresh limit

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
        py27-django1.6-drf{2.4.3,2.4.4,3.0.0,3.1.0}: django-oauth2-provider==0.2.6.1
        pytest-django==2.8.0
        py27-django{1.6,1.7,1.8}-drf3.1.0: djangorestframework-oauth==1.0.1
+       freezegun==0.3.2
 
 [testenv:py27-flake8]
 commands = ./runtests.py --lintonly


### PR DESCRIPTION
Allow an expired token ( `now()` > `exp` + `JWT_EXPIRATION_DELTA` ) to be refreshed.

This pr is built on top of #108.
It should be rebased after #108 is merged (if any).
Just create the PR for review.