### PR TITLE
Proof of concept for token invalidation based on user's data

### DIFF
--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -59,7 +59,7 @@ class JSONWebTokenSerializer(Serializer):
                     msg = _('User account is disabled.')
                     raise serializers.ValidationError(msg)
 
-                payload = jwt_payload_handler(user)
+                payload, salt = jwt_payload_handler(user)
 
                 # Include original issued at time for a brand new token,
                 # to allow token refresh
@@ -69,7 +69,7 @@ class JSONWebTokenSerializer(Serializer):
                     )
 
                 return {
-                    'token': jwt_encode_handler(payload),
+                    'token': jwt_encode_handler(payload, salt),
                     'user': user
                 }
             else:
@@ -171,10 +171,10 @@ class RefreshJSONWebTokenSerializer(VerificationBaseSerializer):
             msg = _('orig_iat field is required.')
             raise serializers.ValidationError(msg)
 
-        new_payload = jwt_payload_handler(user)
+        new_payload, salt = jwt_payload_handler(user)
         new_payload['orig_iat'] = orig_iat
 
         return {
-            'token': jwt_encode_handler(new_payload),
+            'token': jwt_encode_handler(new_payload, salt),
             'user': user
         }

--- a/rest_framework_jwt/settings.py
+++ b/rest_framework_jwt/settings.py
@@ -23,6 +23,7 @@ DEFAULTS = {
     'rest_framework_jwt.utils.jwt_response_payload_handler',
 
     'JWT_SECRET_KEY': settings.SECRET_KEY,
+    'JWT_SALT_USER_ATTRIBUTES': ('password',),
     'JWT_ALGORITHM': 'HS256',
     'JWT_VERIFY': True,
     'JWT_VERIFY_EXPIRATION': True,

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -16,6 +16,11 @@ def get_user_model():
     return User
 
 
+def get_salt_values_from_user(user):
+    return tuple(getattr(user, attr) for attr
+                 in api_settings.JWT_SALT_USER_ATTRIBUTES)
+
+
 def jwt_payload_handler(user):
     try:
         username = user.get_username()
@@ -27,7 +32,7 @@ def jwt_payload_handler(user):
         'email': user.email,
         'username': username,
         'exp': datetime.utcnow() + api_settings.JWT_EXPIRATION_DELTA
-    }
+    }, get_salt_values_from_user(user)
 
 
 def jwt_get_user_id_from_payload_handler(payload):
@@ -38,10 +43,10 @@ def jwt_get_user_id_from_payload_handler(payload):
     return user_id
 
 
-def jwt_encode_handler(payload):
+def jwt_encode_handler(payload, salt=()):
     return jwt.encode(
         payload,
-        api_settings.JWT_SECRET_KEY,
+        ''.join((api_settings.JWT_SECRET_KEY,) + salt),
         api_settings.JWT_ALGORITHM
     ).decode('utf-8')
 
@@ -50,10 +55,19 @@ def jwt_decode_handler(token):
     options = {
         'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
     }
+    unsafe_payload = jwt.decode(token, verify=False)
+    user_id = jwt_get_user_id_from_payload_handler(unsafe_payload)
+    User = get_user_model()
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        salt = ()
+    else:
+        salt = get_salt_values_from_user(user)
 
     return jwt.decode(
         token,
-        api_settings.JWT_SECRET_KEY,
+        ''.join((api_settings.JWT_SECRET_KEY,) + salt),
         api_settings.JWT_VERIFY,
         options=options,
         leeway=api_settings.JWT_LEEWAY,

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -83,8 +83,8 @@ class JSONWebTokenAuthenticationTests(TestCase):
         Ensure POSTing form over JWT auth with correct credentials
         passes and does not require CSRF
         """
-        payload = utils.jwt_payload_handler(self.user)
-        token = utils.jwt_encode_handler(payload)
+        payload, salt = utils.jwt_payload_handler(self.user)
+        token = utils.jwt_encode_handler(payload, salt)
 
         auth = 'JWT {0}'.format(token)
         response = self.csrf_client.post(
@@ -97,8 +97,8 @@ class JSONWebTokenAuthenticationTests(TestCase):
         Ensure POSTing JSON over JWT auth with correct credentials
         passes and does not require CSRF
         """
-        payload = utils.jwt_payload_handler(self.user)
-        token = utils.jwt_encode_handler(payload)
+        payload, salt = utils.jwt_payload_handler(self.user)
+        token = utils.jwt_encode_handler(payload, salt)
 
         auth = 'JWT {0}'.format(token)
         response = self.csrf_client.post(
@@ -158,9 +158,9 @@ class JSONWebTokenAuthenticationTests(TestCase):
         """
         Ensure POSTing over JWT auth with expired token fails
         """
-        payload = utils.jwt_payload_handler(self.user)
+        payload, salt = utils.jwt_payload_handler(self.user)
         payload['exp'] = 1
-        token = utils.jwt_encode_handler(payload)
+        token = utils.jwt_encode_handler(payload, salt)
 
         auth = 'JWT {0}'.format(token)
         response = self.csrf_client.post(
@@ -255,8 +255,8 @@ class JSONWebTokenAuthenticationTests(TestCase):
         """
         api_settings.JWT_AUTH_HEADER_PREFIX = 'Bearer'
 
-        payload = utils.jwt_payload_handler(self.user)
-        token = utils.jwt_encode_handler(payload)
+        payload, salt = utils.jwt_payload_handler(self.user)
+        token = utils.jwt_encode_handler(payload, salt)
 
         auth = 'Bearer {0}'.format(token)
         response = self.csrf_client.post(


### PR DESCRIPTION
NOTHING to merge here !!

This is a proof of concept to illustrate what is inlined in #105

I expect from this example, to come up with some specification for a backward compatible implementation. With some sane defaults, sane interfaces and better naming.

There is open questions behind this example:
- Should we support attributes only from the `User` or from any Model ?
- Since we decode the token two times, does it have a big impact on performances ?
- Since we extract `user_id` from an unsafe_payload is there is a security vulnerability that is introduced if two users share the same `password` ?