### PR TITLE
Added the ability to use custom renderers for the JWT endpoints.

### DIFF
--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -1,7 +1,5 @@
 from rest_framework.views import APIView
 from rest_framework import status
-from rest_framework import parsers
-from rest_framework import renderers
 from rest_framework.response import Response
 
 from rest_framework_jwt.settings import api_settings
@@ -21,8 +19,6 @@ class JSONWebTokenAPIView(APIView):
     throttle_classes = ()
     permission_classes = ()
     authentication_classes = ()
-    parser_classes = (parsers.FormParser, parsers.JSONParser,)
-    renderer_classes = (renderers.JSONRenderer,)
 
     def get_serializer_context(self):
         """


### PR DESCRIPTION
Ran into a use-case today where I wanted to modify the format of the error response from a failed login attempt. I've already written a DRF custom renderer to neatly wrap my responses and errors, and I thought it would be cool if I could apply this renderer to the JWT endpoints as well. 

As far as I can tell it's an extremely simple change! Would definitely appreciate thoughts and feedback though.