### PR TITLE
Remove policy overrides in JSONWebTokenAPIView

### DIFF
--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -16,9 +16,6 @@ class JSONWebTokenAPIView(APIView):
     """
     Base API View that various JWT interactions inherit from.
     """
-    throttle_classes = ()
-    permission_classes = ()
-    authentication_classes = ()
 
     def get_serializer_context(self):
         """


### PR DESCRIPTION
Allows default settings for `throttle_classes`, `permission_classes`, `authentication_classes`to be inherited from django-rest-framework's `APIView`.  