### PR TITLE
updated request handling to match new DRF 3.2 deprecations

### DIFF
--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -21,7 +21,10 @@ class ObtainJSONWebToken(APIView):
     serializer_class = JSONWebTokenSerializer
 
     def post(self, request):
-        serializer = self.serializer_class(data=request.DATA)
+        try:
+            serializer = self.serializer_class(data=request.DATA)
+        except NotImplementedError:
+            serializer = self.serializer_class(data=request.data)
         if serializer.is_valid():
             return Response({'token': serializer.object['token']})
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -43,7 +46,10 @@ class RefreshJSONWebToken(APIView):
     serializer_class = RefreshJSONWebTokenSerializer
 
     def post(self, request):
-        serializer = self.serializer_class(data=request.DATA)
+        try:
+            serializer = self.serializer_class(data=request.DATA)
+        except NotImplementedError:
+            serializer = self.serializer_class(data=request.data)
         if serializer.is_valid():
             return Response({'token': serializer.object['token']})
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Release Notes: [http://www.django-rest-framework.org/topics/3.2-announcement/](http://www.django-rest-framework.org/topics/3.2-announcement/)

Relevant Error: [https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/request.py#L453](https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/request.py#L453)

The full deprecation of `request.DATA` in the main line of DRF was released today, which broke the views code in this app. I added a `try/except` block around the request handling and left `.DATA` as the try clause to support DRF versions under 3.