### PR TITLE
Fixes #150 "AttributeError: 'module' object has no attribute 'serializers'"

### DIFF
--- a/rest_framework_jwt/compat.py
+++ b/rest_framework_jwt/compat.py
@@ -9,6 +9,7 @@ if StrictVersion(rest_framework.VERSION) < StrictVersion('3.0.0'):
     class PasswordField(CharField):
         widget = widgets.PasswordInput
 else:
+    import rest_framework.serializers
     class Serializer(rest_framework.serializers.Serializer):
         @property
         def object(self):

--- a/rest_framework_jwt/compat.py
+++ b/rest_framework_jwt/compat.py
@@ -9,7 +9,9 @@ if StrictVersion(rest_framework.VERSION) < StrictVersion('3.0.0'):
     class PasswordField(CharField):
         widget = widgets.PasswordInput
 else:
+    # Mid-file import to potentially prevent issues occuring for DRF pre 3.0.0
     import rest_framework.serializers
+
     class Serializer(rest_framework.serializers.Serializer):
         @property
         def object(self):

--- a/rest_framework_jwt/compat.py
+++ b/rest_framework_jwt/compat.py
@@ -1,4 +1,5 @@
 import rest_framework
+import rest_framework.serializers
 from django.forms import widgets
 from distutils.version import StrictVersion
 
@@ -9,9 +10,6 @@ if StrictVersion(rest_framework.VERSION) < StrictVersion('3.0.0'):
     class PasswordField(CharField):
         widget = widgets.PasswordInput
 else:
-    # Mid-file import to potentially prevent issues occuring for DRF pre 3.0.0
-    import rest_framework.serializers
-
     class Serializer(rest_framework.serializers.Serializer):
         @property
         def object(self):


### PR DESCRIPTION
rest_framework does not have serializers object so needs an explicit
import. Added the import into the >=3.0 code only so does not affect
older DRF versions if this is something new.