### PR TITLE
Only get_user_model at runtime, avoiding AppRegistryNotReady error w. custom models

### DIFF
--- a/rest_framework_jwt/authentication.py
+++ b/rest_framework_jwt/authentication.py
@@ -10,7 +10,6 @@ from rest_framework_jwt.compat import get_user_model
 from rest_framework_jwt.settings import api_settings
 
 
-User = get_user_model()
 jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
 jwt_get_username_from_payload = api_settings.JWT_PAYLOAD_GET_USERNAME_HANDLER
 
@@ -48,6 +47,7 @@ class BaseJSONWebTokenAuthentication(BaseAuthentication):
         """
         Returns an active user that matches the payload's user id and email.
         """
+        User = get_user_model()
         username = jwt_get_username_from_payload(payload)
 
         if not username:


### PR DESCRIPTION

While using custom model, an error was throwed : django.core.exceptions.AppRegistryNotReady: Models aren't loaded yet. This patch fixes it.
I think it's #70 that was not fully fixed (it's same symptoms at least)

Full stacktrace of fixed error:

```
$ ./manage runserver
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/django/core/management/__init__.py", line 338, in execute_from_command_line
    utility.execute()
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/django/core/management/__init__.py", line 312, in execute
    django.setup()
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/django/apps/registry.py", line 108, in populate
    app_config.import_models(all_models)
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/django/apps/config.py", line 198, in import_models
    self.models_module = import_module(models_module_name)
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2231, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2214, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2203, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1448, in exec_module
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "/home/jocelyn/owk/munch/utils/models.py", line 4, in <module>
    from .mixins import (OwnedModelMixin, OptionnallyOwnedModelMixin,
  File "/home/jocelyn/owk/munch/utils/mixins.py", line 5, in <module>
    from rest_framework.generics import get_object_or_404
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/rest_framework/generics.py", line 8, in <module>
    from rest_framework import views, mixins
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/rest_framework/views.py", line 91, in <module>
    class APIView(View):
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/rest_framework/views.py", line 96, in APIView
    authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/rest_framework/settings.py", line 206, in __getattr__
    val = perform_import(val, attr)
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/rest_framework/settings.py", line 158, in perform_import
    return [import_from_string(item, setting_name) for item in val]
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/rest_framework/settings.py", line 158, in <listcomp>
    return [import_from_string(item, setting_name) for item in val]
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/rest_framework/settings.py", line 170, in import_from_string
    module = importlib.import_module(module_path)
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/jocelyn/owk/django-rest-framework-jwt/rest_framework_jwt/authentication.py", line 13, in <module>
    User = get_user_model()
  File "/home/jocelyn/owk/django-rest-framework-jwt/rest_framework_jwt/compat.py", line 29, in get_user_model
    User = get_user_model()
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/django/contrib/auth/__init__.py", line 150, in get_user_model
    return django_apps.get_model(settings.AUTH_USER_MODEL)
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/django/apps/registry.py", line 199, in get_model
    self.check_models_ready()
  File "/home/jocelyn/.virtualenvs/munch/lib/python3.4/site-packages/django/apps/registry.py", line 131, in check_models_ready
    raise AppRegistryNotReady("Models aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Models aren't loaded yet.
```