### PR TITLE
Feature/encode decode mixin

### DIFF
--- a/rest_framework_jwt/authentication.py
+++ b/rest_framework_jwt/authentication.py
@@ -8,13 +8,13 @@ from rest_framework.authentication import (
 
 from rest_framework_jwt.compat import get_user_model
 from rest_framework_jwt.settings import api_settings
+from rest_framework_jwt.utils import JWTEncodeDecodeMixin
 
 
-jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
 jwt_get_username_from_payload = api_settings.JWT_PAYLOAD_GET_USERNAME_HANDLER
 
 
-class BaseJSONWebTokenAuthentication(BaseAuthentication):
+class BaseJSONWebTokenAuthentication(JWTEncodeDecodeMixin, BaseAuthentication):
     """
     Token based authentication using the JSON Web Token standard.
     """
@@ -29,7 +29,7 @@ class BaseJSONWebTokenAuthentication(BaseAuthentication):
             return None
 
         try:
-            payload = jwt_decode_handler(jwt_value)
+            payload = self.decode(jwt_value)
         except jwt.ExpiredSignature:
             msg = _('Signature has expired.')
             raise exceptions.AuthenticationFailed(msg)

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -1,17 +1,13 @@
-import jwt
-
 from calendar import timegm
 from datetime import datetime, timedelta
 
 from django.contrib.auth import authenticate
 from django.utils.translation import ugettext as _
 from rest_framework import serializers
-from .compat import Serializer
-
+from rest_framework_jwt.compat import (get_user_model, get_username_field,
+                                       PasswordField, Serializer)
 from rest_framework_jwt.settings import api_settings
-from rest_framework_jwt.compat import (
-    get_user_model, get_username_field, PasswordField
-)
+import jwt
 
 
 User = get_user_model()

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -7,17 +7,16 @@ from rest_framework import serializers
 from rest_framework_jwt.compat import (get_user_model, get_username_field,
                                        PasswordField, Serializer)
 from rest_framework_jwt.settings import api_settings
+from rest_framework_jwt.utils import JWTEncodeDecodeMixin
 import jwt
 
 
 User = get_user_model()
 jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
-jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
-jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
 jwt_get_username_from_payload = api_settings.JWT_PAYLOAD_GET_USERNAME_HANDLER
 
 
-class JSONWebTokenSerializer(Serializer):
+class JSONWebTokenSerializer(JWTEncodeDecodeMixin, Serializer):
     """
     Serializer class used to validate a username and password.
 
@@ -55,7 +54,7 @@ class JSONWebTokenSerializer(Serializer):
                 payload = jwt_payload_handler(user)
 
                 return {
-                    'token': jwt_encode_handler(payload),
+                    'token': self.encode(payload),
                     'user': user
                 }
             else:
@@ -67,7 +66,7 @@ class JSONWebTokenSerializer(Serializer):
             raise serializers.ValidationError(msg)
 
 
-class VerificationBaseSerializer(Serializer):
+class VerificationBaseSerializer(JWTEncodeDecodeMixin, Serializer):
     """
     Abstract serializer used for verifying and refreshing JWTs.
     """
@@ -81,7 +80,7 @@ class VerificationBaseSerializer(Serializer):
         # Check payload valid (based off of JSONWebTokenAuthentication,
         # may want to refactor)
         try:
-            payload = jwt_decode_handler(token)
+            payload = self.decode(token)
         except jwt.ExpiredSignature:
             msg = _('Signature has expired.')
             raise serializers.ValidationError(msg)
@@ -116,7 +115,6 @@ class VerifyJSONWebTokenSerializer(VerificationBaseSerializer):
     """
     Check the veracity of an access token.
     """
-
     def validate(self, attrs):
         token = attrs['token']
 
@@ -133,7 +131,6 @@ class RefreshJSONWebTokenSerializer(VerificationBaseSerializer):
     """
     Refresh an access token.
     """
-
     def validate(self, attrs):
         token = attrs['token']
 
@@ -164,6 +161,6 @@ class RefreshJSONWebTokenSerializer(VerificationBaseSerializer):
         new_payload['orig_iat'] = orig_iat
 
         return {
-            'token': jwt_encode_handler(new_payload),
+            'token': self.encode(new_payload),
             'user': user
         }

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -32,21 +32,13 @@ class JWTEncodeDecodeMixin(object):
         return self.jwt_algorithms
 
     def get_jwt_audience(self):
-        if self.jwt_audience is None:
-            return api_settings.JWT_AUDIENCE
-        return self.jwt_audience
+        return self.jwt_audience or api_settings.JWT_AUDIENCE
 
     def get_jwt_encode_algorithm(self):
-        if self.jwt_encode_algorithm is None:
-            return api_settings.JWT_ALGORITHM
-
-        return self.jwt_encode_algorithm
+        return self.jwt_encode_algorithm or api_settings.JWT_ALGORITHM
 
     def get_jwt_issuer(self):
-        if self.jwt_issuer is None:
-            return api_settings.JWT_ISSUER
-
-        return self.jwt_issuer
+        return self.jwt_issuer or api_settings.JWT_ISSUER
 
     def get_jwt_leeway(self):
         if self.jwt_leeway is None:
@@ -60,10 +52,7 @@ class JWTEncodeDecodeMixin(object):
         return self.jwt_leeway
 
     def get_jwt_secret_key(self):
-        if self.jwt_secret_key is None:
-            return api_settings.JWT_SECRET_KEY
-
-        return self.jwt_secret_key
+        return self.jwt_secret_key or api_settings.JWT_SECRET_KEY
 
     def get_jwt_verify(self):
         if self.jwt_verify is None:

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -1,13 +1,13 @@
-from rest_framework.views import APIView
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from .settings import api_settings
 from .compat import get_request_data
-from .serializers import (
-    JSONWebTokenSerializer, RefreshJSONWebTokenSerializer,
-    VerifyJSONWebTokenSerializer
-)
+from .serializers import (JSONWebTokenSerializer,
+                          RefreshJSONWebTokenSerializer,
+                          VerifyJSONWebTokenSerializer)
+from .settings import api_settings
+
 
 jwt_response_payload_handler = api_settings.JWT_RESPONSE_PAYLOAD_HANDLER
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -77,6 +77,7 @@ class JSONWebTokenAuthenticationTests(TestCase):
         self.username = 'jpueblo'
         self.email = 'jpueblo@example.com'
         self.user = User.objects.create_user(self.username, self.email)
+        self.encode_decode_mixin = utils.JWTEncodeDecodeMixin()
 
     def test_post_form_passing_jwt_auth(self):
         """
@@ -84,7 +85,7 @@ class JSONWebTokenAuthenticationTests(TestCase):
         passes and does not require CSRF
         """
         payload = utils.jwt_payload_handler(self.user)
-        token = utils.jwt_encode_handler(payload)
+        token = self.encode_decode_mixin.encode(payload)
 
         auth = 'JWT {0}'.format(token)
         response = self.csrf_client.post(
@@ -98,7 +99,7 @@ class JSONWebTokenAuthenticationTests(TestCase):
         passes and does not require CSRF
         """
         payload = utils.jwt_payload_handler(self.user)
-        token = utils.jwt_encode_handler(payload)
+        token = self.encode_decode_mixin.encode(payload)
 
         auth = 'JWT {0}'.format(token)
         response = self.csrf_client.post(
@@ -160,7 +161,7 @@ class JSONWebTokenAuthenticationTests(TestCase):
         """
         payload = utils.jwt_payload_handler(self.user)
         payload['exp'] = 1
-        token = utils.jwt_encode_handler(payload)
+        token = self.encode_decode_mixin.encode(payload)
 
         auth = 'JWT {0}'.format(token)
         response = self.csrf_client.post(
@@ -196,7 +197,7 @@ class JSONWebTokenAuthenticationTests(TestCase):
         has priority on authentication_classes
         """
         payload = utils.jwt_payload_handler(self.user)
-        token = utils.jwt_encode_handler(payload)
+        token = self.encode_decode_mixin.encode(payload)
 
         auth = 'JWT {0}'.format(token)
         response = self.csrf_client.post(
@@ -237,7 +238,7 @@ class JSONWebTokenAuthenticationTests(TestCase):
         Ensure POSTing json over JWT auth with invalid payload fails
         """
         payload = dict(email=None)
-        token = utils.jwt_encode_handler(payload)
+        token = self.encode_decode_mixin.encode(payload)
 
         auth = 'JWT {0}'.format(token)
         response = self.csrf_client.post(
@@ -256,7 +257,7 @@ class JSONWebTokenAuthenticationTests(TestCase):
         api_settings.JWT_AUTH_HEADER_PREFIX = 'Bearer'
 
         payload = utils.jwt_payload_handler(self.user)
-        token = utils.jwt_encode_handler(payload)
+        token = self.encode_decode_mixin.encode(payload)
 
         auth = 'Bearer {0}'.format(token)
         response = self.csrf_client.post(

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -26,6 +26,7 @@ class JSONWebTokenSerializerTests(TestCase):
             'username': self.username,
             'password': self.password
         }
+        self.encode_decode_mixin = utils.JWTEncodeDecodeMixin()
 
     @unittest.skipUnless(drf2, 'not supported in this version')
     def test_empty_drf2(self):
@@ -51,7 +52,7 @@ class JSONWebTokenSerializerTests(TestCase):
         is_valid = serializer.is_valid()
 
         token = serializer.object['token']
-        decoded_payload = utils.jwt_decode_handler(token)
+        decoded_payload = self.encode_decode_mixin.decode(token)
 
         self.assertTrue(is_valid)
         self.assertEqual(decoded_payload['username'], self.username)


### PR DESCRIPTION
![we're becoming homies!](http://www.reactiongifs.com/r/hmies1.gif)

## Mixin based encoder and decoder

So this is a fairly large change and it's not yet 100%. However, all current tests are passing and all Python/Django/DRF versions are passing through `tox`. I have not written tests specifically for the mixin yet, but will should you all decide this is viable. I would probably also move the mixin to a separate file.

The issue I have run into with your package is that it's not flexible when it comes to changing settings per API endpoint or serializer. My need for this package is to have the standard Django users API end points for auth & verify. I also need a set of API end points for superuser auth/very & CRUD operations. Standard users will use the default secret of `SECRET_KEY`. Superusers or rather other micro services will access the superuser end points with a separate key.

To use a different secret key for my sub-class of `JSONWebTokenAuthentication` I had to create a separate `decode_handler` so that I could specify a secret other than `settings.JWT_SECRET`, then I had to sub-class `JSONWebTokenAuthentication` & override the `authenticate` method so that I could use the new decoder. This felt needlessly complex and then I have to worry about package upgrades breaking my custom `authenticate` method.

So, my idea was to provide a mixin `JWTEncodeDecodeMixin` (name isn't set in stone and it might make sense to break it into EncodeMixin & DecodeMixin) that made it easy to either set all of the JWT properties or override the getters per API to build something up dynamically. All of the original defaults exist and work as before, with the exception of the encode and decode handlers setting. It works now because I have not yet removed the functions. I have replaced all usage of those functions throughout the codebase and updated the tests.

This mixin would make it possible to easily create your own authentication sub-classes and easily set specific settings based on your needs, or if you wanted to get crazy enough, figure out those settings based on dynamic factors by overriding the methods.

Example usage:

```python
from djangorestframework-jwt.authentication import JSONWebTokenAuthentication


class SuperUserAuthentication(JSONWebTokenAuthentication):
    jwt_secret_key = "somesupersecretkey"


class SomeCrazyAuthentication(JSONWebTokenAuthentication):
    def get_jwt_secret_key(self):
        # ... do something to dynamically figure out the key
        return key
```

I have to spend some more time tomorrow checking to see if this will be backwards incompatible. I don't think so but I'm not yet positive. I also haven't written any docs yet. Those would probably be pretty extensive. Thoughts? I want to make sure this is something you'll consider merging in before I spend more time on it or pull pieces and build something custom for my own needs.