### PR TITLE
Added functionality to authenticate from querystring

### DIFF
--- a/rest_framework_jwt/authentication.py
+++ b/rest_framework_jwt/authentication.py
@@ -78,6 +78,23 @@ class JSONWebTokenAuthentication(BaseJSONWebTokenAuthentication):
     www_authenticate_realm = 'api'
 
     def get_jwt_value(self, request):
+        auth_query_string_prefix = api_settings.JWT_AUTH_QUERY_STRING_PREFIX.lower()
+
+        if auth_query_string_prefix in request.query_params:
+            return self.get_jwt_value_from_query_string(request)
+        else:
+            return self.get_jwt_value_from_header(request)
+
+    def get_jwt_value_from_query_string(self, request):
+        auth_query_string = request.query_params.get(api_settings.JWT_AUTH_QUERY_STRING_PREFIX.lower())
+
+        if len(auth_query_string) <= 0 :
+            msg = _('Invalid Query String. No value provided.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        return auth_query_string
+
+    def get_jwt_value_from_header(self, request):
         auth = get_authorization_header(request).split()
         auth_header_prefix = api_settings.JWT_AUTH_HEADER_PREFIX.lower()
 

--- a/rest_framework_jwt/settings.py
+++ b/rest_framework_jwt/settings.py
@@ -38,6 +38,7 @@ DEFAULTS = {
     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
+    'JWT_AUTH_QUERY_STRING_PREFIX': 'JWT',
 }
 
 # List of settings that may be in string import notation.


### PR DESCRIPTION
User can now supply token for authentication either via header or via query string