### PR TITLE
Move authentication into a separate method

### DIFF
--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -41,7 +41,7 @@ class JSONWebTokenSerializer(Serializer):
     @property
     def username_field(self):
         return get_username_field()
-        
+
     def authenticate(self, credentials):
         return authenticate(**credentials)
 

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -41,6 +41,9 @@ class JSONWebTokenSerializer(Serializer):
     @property
     def username_field(self):
         return get_username_field()
+        
+    def authenticate(self, credentials):
+        return authenticate(**credentials)
 
     def validate(self, attrs):
         credentials = {
@@ -49,7 +52,7 @@ class JSONWebTokenSerializer(Serializer):
         }
 
         if all(credentials.values()):
-            user = authenticate(**credentials)
+            user = self.authenticate(credentials)
 
             if user:
                 if not user.is_active:


### PR DESCRIPTION
We want to look into allowing users to login with either their username or their email in our internal app. There doesn't seem to be a nice way to support this currently, but with this change the authentication is moved to a authenticate() method, which can be overriden to do whatever.