### PR TITLE
Send user_logged_in signal when a user logs in successfully

### DIFF
--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -4,6 +4,7 @@ from calendar import timegm
 from datetime import datetime, timedelta
 
 from django.contrib.auth import authenticate
+from django.contrib.auth.signals import user_logged_in
 from django.utils.translation import ugettext as _
 from rest_framework import serializers
 from .compat import Serializer
@@ -57,6 +58,8 @@ class JSONWebTokenSerializer(Serializer):
                     raise serializers.ValidationError(msg)
 
                 payload = jwt_payload_handler(user)
+
+                user_logged_in.send(sender=user.__class__, request=self.context['request'], user=user)
 
                 return {
                     'token': jwt_encode_handler(payload),


### PR DESCRIPTION
The standard Django login() function sends the user_logged_in when a user logs in, with this change django-rest-framework-jwt will also send the signal. This is useful if you want to log when a user logs in. The last logged in user field is also updated by a user_logged_in receiver, so that field will also be updated with this change.
