### PR TITLE
Pass input type for PasswordField to the constructor (Fixes #182)

### DIFF
--- a/rest_framework_jwt/compat.py
+++ b/rest_framework_jwt/compat.py
@@ -18,9 +18,13 @@ else:
             return self.validated_data
 
     class PasswordField(serializers.CharField):
-        style = {
-            'input_type': 'password'
-        }
+
+        def __init__(self, *args, **kwargs):
+            if 'style' not in kwargs:
+                kwargs['style'] = {'input_type': 'password'}
+            else:
+                kwargs['style']['input_type'] = 'password'
+            super(PasswordField, self).__init__(*args, **kwargs)
 
 
 def get_user_model():


### PR DESCRIPTION
Instead of setting the attribute directly, I pass it along with all other arguments to the inherited constructor. Thereby it is set there and the password is hidden again.