### PR TITLE
Manage tokens between Multiple hosts (domains)

### DIFF
--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -38,7 +38,7 @@ class JSONWebTokenSerializer(Serializer):
 
         self.fields[self.username_field] = serializers.CharField()
         self.fields['password'] = PasswordField(write_only=True)
-        self.request = kwargs['request']
+        self.request = kwargs['context']['request']
 
     @property
     def username_field(self):
@@ -84,7 +84,7 @@ class VerificationBaseSerializer(Serializer):
         Set self.request
         """
         super(VerificationBaseSerializer, self).__init__(*args, **kwargs)
-        self.request = kwargs['request']
+        self.request = kwargs['context']['request']
 
     def validate(self, attrs):
         msg = 'Please define a validate method.'

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -184,7 +184,7 @@ class RefreshJSONWebTokenSerializer(VerificationBaseSerializer):
             msg = _('orig_iat field is required.')
             raise serializers.ValidationError(msg)
 
-        new_payload = jwt_payload_handler(user)
+        new_payload = jwt_payload_handler(user, self.request)
         new_payload['orig_iat'] = orig_iat
 
         return {

--- a/rest_framework_jwt/settings.py
+++ b/rest_framework_jwt/settings.py
@@ -34,6 +34,8 @@ DEFAULTS = {
     'JWT_AUDIENCE': None,
     'JWT_ISSUER': None,
 
+    'JWT_VERIFY_HOST': False,
+
     'JWT_ALLOW_REFRESH': False,
     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
 

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -7,7 +7,7 @@ from rest_framework_jwt.compat import get_username, get_username_field
 from rest_framework_jwt.settings import api_settings
 
 
-def jwt_payload_handler(user):
+def jwt_payload_handler(user, request):
     username_field = get_username_field()
     username = get_username(user)
 
@@ -21,6 +21,7 @@ def jwt_payload_handler(user):
         'user_id': user.pk,
         'email': user.email,
         'username': username,
+        'host': request.get_host(),
         'exp': datetime.utcnow() + api_settings.JWT_EXPIRATION_DELTA
     }
 


### PR DESCRIPTION

Right now, if the Django application is hosting multiple sites, a token generated from one site can be successfully verified and refreshed by another provided they share the same user/database.  This is not always desired. Django also manages session on a per-site basis.

While working on our multi tenant system in Retailephant.com, we faced this issue where tokens generated from a particular channel that we were hosting were successfully verified and refreshed by another. 

The pull request provides a solution where the setting 'JWT_VERIFY_HOST', with default = False, can be used to configure the desire behavior of verifying and refreshing a token based on the host.
