### PR TITLE
Remove emission of user_logged_in signal when the user is authenticated

### DIFF
--- a/rest_framework_jwt/authentication.py
+++ b/rest_framework_jwt/authentication.py
@@ -1,6 +1,5 @@
 import jwt
 
-from django.contrib.auth.signals import user_logged_in
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _
 from rest_framework import exceptions
@@ -42,7 +41,6 @@ class BaseJSONWebTokenAuthentication(BaseAuthentication):
             raise exceptions.AuthenticationFailed()
 
         user = self.authenticate_credentials(payload)
-        user_logged_in.send(sender=user.__class__, request=request, user=user)
 
         return (user, jwt_value)
 


### PR DESCRIPTION
Following the discussion in https://github.com/GetBlimp/django-rest-framework-jwt/pull/171 and corresponding discussion in https://github.com/tomchristie/django-rest-framework/issues/3869, this pull request removes the signal.