### PR TITLE
add support for emailusernames package

### DIFF
--- a/rest_framework_jwt/authentication.py
+++ b/rest_framework_jwt/authentication.py
@@ -8,7 +8,7 @@ from rest_framework.authentication import (
 )
 
 from rest_framework_jwt.compat import get_user_model
-from rest_framework_jwt.settings import api_settings
+from rest_framework_jwt.settings import api_settings, IS_EMAILUSERNAMES_INSTALLED
 
 
 jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
@@ -55,11 +55,18 @@ class BaseJSONWebTokenAuthentication(BaseAuthentication):
             msg = _('Invalid payload.')
             raise exceptions.AuthenticationFailed(msg)
 
-        try:
-            user = User.objects.get_by_natural_key(username)
-        except User.DoesNotExist:
-            msg = _('Invalid signature.')
-            raise exceptions.AuthenticationFailed(msg)
+        if IS_EMAILUSERNAMES_INSTALLED:
+            try:
+                user = User.objects.get(email=username)
+            except User.DoesNotExist:
+                msg = _('Invalid signature.')
+                raise exceptions.AuthenticationFailed(msg)
+        else:
+            try:
+                user = User.objects.get_by_natural_key(username)
+            except User.DoesNotExist:
+                msg = _('Invalid signature.')
+                raise exceptions.AuthenticationFailed(msg)
 
         if not user.is_active:
             msg = _('User account is disabled.')

--- a/rest_framework_jwt/compat.py
+++ b/rest_framework_jwt/compat.py
@@ -2,6 +2,7 @@ from distutils.version import StrictVersion
 
 import rest_framework
 from rest_framework import serializers
+from rest_framework_jwt.settings import IS_EMAILUSERNAMES_INSTALLED
 from django.forms import widgets
 
 
@@ -39,12 +40,15 @@ def get_user_model():
 
 
 def get_username_field():
-    try:
-        username_field = get_user_model().USERNAME_FIELD
-    except:
-        username_field = 'username'
+    if IS_EMAILUSERNAMES_INSTALLED:
+        return 'email'
+    else:
+        try:
+            username_field = get_user_model().USERNAME_FIELD
+        except:
+            username_field = 'username'
 
-    return username_field
+        return username_field
 
 
 def get_username(user):

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext as _
 from rest_framework import serializers
 from .compat import Serializer
 
-from rest_framework_jwt.settings import api_settings
+from rest_framework_jwt.settings import api_settings, IS_EMAILUSERNAMES_INSTALLED
 from rest_framework_jwt.compat import (
     get_user_model, get_username_field, PasswordField
 )
@@ -103,11 +103,18 @@ class VerificationBaseSerializer(Serializer):
             raise serializers.ValidationError(msg)
 
         # Make sure user exists
-        try:
-            user = User.objects.get_by_natural_key(username)
-        except User.DoesNotExist:
-            msg = _("User doesn't exist.")
-            raise serializers.ValidationError(msg)
+        if IS_EMAILUSERNAMES_INSTALLED:
+            try:
+                user = User.objects.get(email=username)
+            except User.DoesNotExist:
+                msg = _("User doesn't exist.")
+                raise serializers.ValidationError(msg)
+        else:
+            try:
+                user = User.objects.get_by_natural_key(username)
+            except User.DoesNotExist:
+                msg = _("User doesn't exist.")
+                raise serializers.ValidationError(msg)
 
         if not user.is_active:
             msg = _('User account is disabled.')

--- a/rest_framework_jwt/settings.py
+++ b/rest_framework_jwt/settings.py
@@ -3,6 +3,15 @@ import datetime
 from django.conf import settings
 from rest_framework.settings import APISettings
 
+# emailusernames does some monkeypatching, such that get_user_model().USERNAME_FIELD 
+# won't be updated to auth.User.email
+try:
+    import emailusernames
+except ImportError:
+    IS_EMAILUSERNAMES_INSTALLED = False
+else:
+    IS_EMAILUSERNAMES_INSTALLED = True
+
 
 USER_SETTINGS = getattr(settings, 'JWT_AUTH', None)
 


### PR DESCRIPTION
the emailusernames package for django does some horrible monkeypatching, so get_user_model().USERNAME_FIELD won't return auth.User.email.  my fix tries to import the package and if present return the email field as username_field and lookup users by their email.