### PR TITLE
Support for UUID for User PK

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -1,4 +1,5 @@
 import jwt
+import uuid
 import warnings
 from calendar import timegm
 from datetime import datetime
@@ -23,6 +24,8 @@ def jwt_payload_handler(user):
         'username': username,
         'exp': datetime.utcnow() + api_settings.JWT_EXPIRATION_DELTA
     }
+    if isinstance(user.pk, uuid.UUID):
+        payload['user_id'] = str(user.pk)
 
     payload[username_field] = username
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,8 +1,21 @@
+import uuid
 from django.db import models
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
 
 
 class CustomUser(AbstractBaseUser):
+    email = models.EmailField(max_length=255, unique=True)
+
+    objects = BaseUserManager()
+
+    USERNAME_FIELD = 'email'
+
+    class Meta:
+        app_label = 'tests'
+
+
+class CustomUserUUID(AbstractBaseUser):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     email = models.EmailField(max_length=255, unique=True)
 
     objects = BaseUserManager()


### PR DESCRIPTION
This PR allow to have custom user model with UUID as PK without need to customize django-rest-framework-jwt.

It comes with a test case to validate it actually works with UUID