### PR TITLE
Include request in context when calling the serializer in example code

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -221,7 +221,7 @@ Example:
 def jwt_response_payload_handler(token, user=None, request=None):
     return {
         'token': token,
-        'user': UserSerializer(user).data
+        'user': UserSerializer(user,context={'request': request},).data
     }
 ```
 

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -92,7 +92,7 @@ def jwt_response_payload_handler(token, user=None, request=None):
     def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
-            'user': UserSerializer(user).data
+            'user': UserSerializer(user,context={'request': request},).data
         }
 
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,11 +12,11 @@ def jwt_response_payload_handler(token, user=None, request=None):
     def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
-            'user': UserSerializer(user).data
-        }
+            'user': UserSerializer(user,context={'request': request},).data
+        }   
 
     """
     return {
-        'token': token,
-        'user': UserSerializer(user,context={'request': request},).data
+        'user': get_username(user),
+        'token': token
     }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
             'user': UserSerializer(user,context={'request': request},).data
-        }   
+        }
 
     """
     return {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,6 +17,6 @@ def jwt_response_payload_handler(token, user=None, request=None):
 
     """
     return {
-        'user': get_username(user),
-        'token': token
+        'token': token,
+        'user': UserSerializer(user,context={'request': request},).data
     }


### PR DESCRIPTION
Serializers require the request object to be sent as context when they include hyperlinked relations so they can generate fully qualified URLs. [#Including Extra Context](http://www.django-rest-framework.org/api-guide/serializers/#including-extra-context)