### PR TITLE
Add request context to call on UserSerializer 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -251,7 +251,7 @@ Example:
 def jwt_response_payload_handler(token, user=None, request=None):
     return {
         'token': token,
-        'user': UserSerializer(user,context={'request': request},).data
+        'user': UserSerializer(user,context={'request': request}).data
     }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -251,7 +251,7 @@ Example:
 def jwt_response_payload_handler(token, user=None, request=None):
     return {
         'token': token,
-        'user': UserSerializer(user,context={'request': request}).data
+        'user': UserSerializer(user, context={'request': request}).data
     }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -251,7 +251,7 @@ Example:
 def jwt_response_payload_handler(token, user=None, request=None):
     return {
         'token': token,
-        'user': UserSerializer(user).data
+        'user': UserSerializer(user,context={'request': request},).data
     }
 ```
 

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -101,7 +101,7 @@ def jwt_response_payload_handler(token, user=None, request=None):
     def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
-            'user': UserSerializer(user,context={'request': request}).data
+            'user': UserSerializer(user, context={'request': request}).data
         }
 
     """

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -101,7 +101,7 @@ def jwt_response_payload_handler(token, user=None, request=None):
     def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
-            'user': UserSerializer(user).data
+            'user': UserSerializer(user,context={'request': request},).data
         }
 
     """

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -101,7 +101,7 @@ def jwt_response_payload_handler(token, user=None, request=None):
     def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
-            'user': UserSerializer(user,context={'request': request},).data
+            'user': UserSerializer(user,context={'request': request}).data
         }
 
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,7 @@ def jwt_response_payload_handler(token, user=None, request=None):
     def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
-            'user': UserSerializer(user).data
+            'user': UserSerializer(user,context={'request': request},).data
         }
 
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,7 @@ def jwt_response_payload_handler(token, user=None, request=None):
     def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
-            'user': UserSerializer(user,context={'request': request}).data
+            'user': UserSerializer(user, context={'request': request}).data
         }
 
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,7 @@ def jwt_response_payload_handler(token, user=None, request=None):
     def jwt_response_payload_handler(token, user=None, request=None):
         return {
             'token': token,
-            'user': UserSerializer(user,context={'request': request},).data
+            'user': UserSerializer(user,context={'request': request}).data
         }
 
     """


### PR DESCRIPTION
HypertextModelSerializer based serializers require the request context sent.  This updates the example in comments and docs to reflect that.  Completes Issue #230