### PR TITLE
serializers: fix typo

### DIFF
--- a/rest_framework_jwt/locale/en_US/LC_MESSAGES/django.po
+++ b/rest_framework_jwt/locale/en_US/LC_MESSAGES/django.po
@@ -47,7 +47,7 @@ msgid "User account is disabled."
 msgstr ""
 
 #: serializers.py:76
-msgid "Unable to login with provided credentials."
+msgid "Unable to log in with provided credentials."
 msgstr ""
 
 #: serializers.py:79

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -61,7 +61,7 @@ class JSONWebTokenSerializer(Serializer):
                     'user': user
                 }
             else:
-                msg = _('Unable to login with provided credentials.')
+                msg = _('Unable to log in with provided credentials.')
                 raise serializers.ValidationError(msg)
         else:
             msg = _('Must include "{username_field}" and "password".')


### PR DESCRIPTION
- "log in": adverb (action)
- "login": noun
