### PR TITLE
APIJWTClient login with any credential format

### DIFF
--- a/rest_framework_jwt/test.py
+++ b/rest_framework_jwt/test.py
@@ -4,13 +4,13 @@ from rest_framework_jwt.settings import api_settings
 
 
 class APIJWTClient(APIClient):
-    def login(self, username, password):
+    def login(self, **credentials):
         """
         Returns True if login is possible; False if the provided credentials
         are incorrect, or the user is inactive.
         """
-        response = self.post('/api-token-auth/', {"username": username, "password": password},
-                             format='json')
+
+        response = self.post('/api-token-auth/', credentials, format='json')
         if response.status_code == status.HTTP_200_OK:
             self.credentials(
                 HTTP_AUTHORIZATION="{0} {1}".format(api_settings.JWT_AUTH_HEADER_PREFIX, response.data['token']))


### PR DESCRIPTION
(As mentioned in #246)

We're using emails as usernames in our project, but the `APIJWTClient.login` method assumes usernames are used.

Another option would be to use `get_username_field` [1](https://github.com/GetBlimp/django-rest-framework-jwt/blob/00f76e44da4a2b62075696cce1f583dd735ff197/rest_framework_jwt/compat.py#L22), but I think this is the better solution.
It matches what `django.test.client.Client` does [2](https://github.com/django/django/blob/9baf692a58de78dba13aa582098781675367c329/django/test/client.py#L613).