### PR TITLE
Add support for Django 1.10 and Django REST Framework 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,12 @@ env:
     - TOX_ENV=py27-django1.8-drf3.1
     - TOX_ENV=py27-django1.8-drf3.2
     - TOX_ENV=py27-django1.8-drf3.3
+    - TOX_ENV=py27-django1.8-drf3.4
 
     - TOX_ENV=py27-django1.9-drf3.1
     - TOX_ENV=py27-django1.9-drf3.2
     - TOX_ENV=py27-django1.9-drf3.3
+    - TOX_ENV=py27-django1.9-drf3.4
 
     - TOX_ENV=py27-django1.10-drf3.4
 
@@ -21,15 +23,18 @@ env:
     - TOX_ENV=py33-django1.8-drf3.1
     - TOX_ENV=py33-django1.8-drf3.2
     - TOX_ENV=py33-django1.8-drf3.3
+    - TOX_ENV=py33-django1.8-drf3.4
 
     - TOX_ENV=py34-django1.8-drf3.0
     - TOX_ENV=py34-django1.8-drf3.1
     - TOX_ENV=py34-django1.8-drf3.2
     - TOX_ENV=py34-django1.8-drf3.3
+    - TOX_ENV=py34-django1.8-drf3.4
 
     - TOX_ENV=py34-django1.9-drf3.1
     - TOX_ENV=py34-django1.9-drf3.2
     - TOX_ENV=py34-django1.9-drf3.3
+    - TOX_ENV=py34-django1.9-drf3.4
 
     - TOX_ENV=py34-django1.10-drf3.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
     - TOX_ENV=py27-django1.9-drf3.2
     - TOX_ENV=py27-django1.9-drf3.3
 
+    - TOX_ENV=py27-django1.10-drf3.4
+
     - TOX_ENV=py33-django1.8-drf3.0
     - TOX_ENV=py33-django1.8-drf3.1
     - TOX_ENV=py33-django1.8-drf3.2
@@ -28,6 +30,8 @@ env:
     - TOX_ENV=py34-django1.9-drf3.1
     - TOX_ENV=py34-django1.9-drf3.2
     - TOX_ENV=py34-django1.9-drf3.3
+
+    - TOX_ENV=py34-django1.10-drf3.4
 
 matrix:
   fast_finish: true

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,8 @@ Requirements
 ------------
 
 -  Python (2.7, 3.3, 3.4)
--  Django (1.8, 1.9)
--  Django REST Framework (3.0, 3.1, 3.2, 3.3)
+-  Django (1.8, 1.9, 1.10)
+-  Django REST Framework (3.0, 3.1, 3.2, 3.3, 3.4)
 
 Installation
 ------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,8 +28,8 @@ If you want to know more about JWT, check out the following resources:
 ## Requirements
 
 - Python (2.7, 3.3, 3.4)
-- Django (1.8, 1.9)
-- Django REST Framework (3.0, 3.1, 3.2, 3.3)
+- Django (1.8, 1.9, 1.10)
+- Django REST Framework (3.0, 3.1, 3.2, 3.3, 3.4)
 
 ## Security
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,17 +1,7 @@
 import unittest
 
-from django.http import HttpResponse
 from django.test import TestCase
-from django.conf.urls import url
-
-from rest_framework import permissions, status
-try:
-    from rest_framework_oauth.authentication import OAuth2Authentication
-except ImportError:
-    try:
-        from rest_framework.authentication import OAuth2Authentication
-    except ImportError:
-        OAuth2Authentication = None
+from rest_framework import status
 try:
     try:
         from rest_framework_oauth.compat import oauth2_provider
@@ -30,12 +20,10 @@ except ImportError:
         oauth2_provider = None
 
 from rest_framework.test import APIRequestFactory, APIClient
-from rest_framework.views import APIView
 
 from rest_framework_jwt import utils
 from rest_framework_jwt.compat import get_user_model
 from rest_framework_jwt.settings import api_settings, DEFAULTS
-from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
 User = get_user_model()
 
@@ -44,33 +32,8 @@ DJANGO_OAUTH2_PROVIDER_NOT_INSTALLED = 'django-oauth2-provider not installed'
 factory = APIRequestFactory()
 
 
-class MockView(APIView):
-    permission_classes = (permissions.IsAuthenticated,)
-
-    def get(self, request):
-        return HttpResponse({'a': 1, 'b': 2, 'c': 3})
-
-    def post(self, request):
-        return HttpResponse({'a': 1, 'b': 2, 'c': 3})
-
-
-urlpatterns = [
-    url(r'^jwt/$', MockView.as_view(
-     authentication_classes=[JSONWebTokenAuthentication])),
-
-    url(r'^jwt-oauth2/$', MockView.as_view(
-        authentication_classes=[
-            JSONWebTokenAuthentication, OAuth2Authentication])),
-
-    url(r'^oauth2-jwt/$', MockView.as_view(
-        authentication_classes=[
-            OAuth2Authentication, JSONWebTokenAuthentication])),
-]
-
-
 class JSONWebTokenAuthenticationTests(TestCase):
     """JSON Web Token Authentication"""
-    urls = 'tests.test_authentication'
 
     def setUp(self):
         self.csrf_client = APIClient(enforce_csrf_checks=True)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -2,7 +2,7 @@ import unittest
 
 from django.http import HttpResponse
 from django.test import TestCase
-from django.conf.urls import patterns
+from django.conf.urls import url
 
 from rest_framework import permissions, status
 try:
@@ -54,19 +54,18 @@ class MockView(APIView):
         return HttpResponse({'a': 1, 'b': 2, 'c': 3})
 
 
-urlpatterns = patterns(
-    '',
-    (r'^jwt/$', MockView.as_view(
+urlpatterns = [
+    url(r'^jwt/$', MockView.as_view(
      authentication_classes=[JSONWebTokenAuthentication])),
 
-    (r'^jwt-oauth2/$', MockView.as_view(
+    url(r'^jwt-oauth2/$', MockView.as_view(
         authentication_classes=[
             JSONWebTokenAuthentication, OAuth2Authentication])),
 
-    (r'^oauth2-jwt/$', MockView.as_view(
+    url(r'^oauth2-jwt/$', MockView.as_view(
         authentication_classes=[
             OAuth2Authentication, JSONWebTokenAuthentication])),
-)
+]
 
 
 class JSONWebTokenAuthenticationTests(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,19 +3,17 @@ from calendar import timegm
 from datetime import datetime, timedelta
 import time
 
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
 from django import get_version
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.conf.urls import url
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from rest_framework_jwt import utils, views
+from rest_framework_jwt import utils
 from rest_framework_jwt.compat import get_user_model
 from rest_framework_jwt.settings import api_settings, DEFAULTS
-
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import rsa
 
 from . import utils as test_utils
 
@@ -23,17 +21,10 @@ User = get_user_model()
 
 NO_CUSTOM_USER_MODEL = 'Custom User Model only supported after Django 1.5'
 
-urlpatterns = [
-    url(r'^auth-token/$', views.obtain_jwt_token),
-    url(r'^auth-token-refresh/$', views.refresh_jwt_token),
-    url(r'^auth-token-verify/$', views.verify_jwt_token),
-]
-
 orig_datetime = datetime
 
 
 class BaseTestCase(TestCase):
-    urls = 'tests.test_views'
 
     def setUp(self):
         self.email = 'jpueblo@example.com'
@@ -67,7 +58,6 @@ class TestCustomResponsePayload(BaseTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(decoded_payload['username'], self.username)
-        self.assertEqual(response.data['user'], self.username)
 
     def tearDown(self):
         api_settings.JWT_RESPONSE_PAYLOAD_HANDLER =\
@@ -164,7 +154,6 @@ class ObtainJSONWebTokenTests(BaseTestCase):
 @override_settings(AUTH_USER_MODEL='tests.CustomUser')
 class CustomUserObtainJSONWebTokenTests(TestCase):
     """JSON Web Token Authentication"""
-    urls = 'tests.test_views'
 
     def setUp(self):
         from .models import CustomUser
@@ -209,7 +198,6 @@ class CustomUserObtainJSONWebTokenTests(TestCase):
 @override_settings(AUTH_USER_MODEL='tests.CustomUserUUID')
 class CustomUserUUIDObtainJSONWebTokenTests(TestCase):
     """JSON Web Token Authentication"""
-    urls = 'tests.test_views'
 
     def setUp(self):
         from .models import CustomUserUUID

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -6,11 +6,11 @@ import time
 from django import get_version
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.conf.urls import patterns
+from django.conf.urls import url
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from rest_framework_jwt import utils
+from rest_framework_jwt import utils, views
 from rest_framework_jwt.compat import get_user_model
 from rest_framework_jwt.settings import api_settings, DEFAULTS
 
@@ -23,13 +23,11 @@ User = get_user_model()
 
 NO_CUSTOM_USER_MODEL = 'Custom User Model only supported after Django 1.5'
 
-urlpatterns = patterns(
-    '',
-    (r'^auth-token/$', 'rest_framework_jwt.views.obtain_jwt_token'),
-    (r'^auth-token-refresh/$', 'rest_framework_jwt.views.refresh_jwt_token'),
-    (r'^auth-token-verify/$', 'rest_framework_jwt.views.verify_jwt_token'),
-
-)
+urlpatterns = [
+    url(r'^auth-token/$', views.obtain_jwt_token),
+    url(r'^auth-token-refresh/$', views.refresh_jwt_token),
+    url(r'^auth-token-verify/$', views.verify_jwt_token),
+]
 
 orig_datetime = datetime
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -11,7 +11,7 @@ from django.test.utils import override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from rest_framework_jwt import utils
+from rest_framework_jwt import utils, views
 from rest_framework_jwt.compat import get_user_model
 from rest_framework_jwt.settings import api_settings, DEFAULTS
 
@@ -42,7 +42,8 @@ class BaseTestCase(TestCase):
 class TestCustomResponsePayload(BaseTestCase):
 
     def setUp(self):
-        api_settings.JWT_RESPONSE_PAYLOAD_HANDLER = test_utils\
+        self.original_handler = views.jwt_response_payload_handler
+        views.jwt_response_payload_handler = test_utils\
             .jwt_response_payload_handler
         return super(TestCustomResponsePayload, self).setUp()
 
@@ -58,10 +59,10 @@ class TestCustomResponsePayload(BaseTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(decoded_payload['username'], self.username)
+        self.assertEqual(response.data['user'], self.username)
 
     def tearDown(self):
-        api_settings.JWT_RESPONSE_PAYLOAD_HANDLER =\
-            DEFAULTS['JWT_RESPONSE_PAYLOAD_HANDLER']
+        views.jwt_response_payload_handler = self.original_handler
 
 
 class ObtainJSONWebTokenTests(BaseTestCase):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,4 @@
 """
 Blank URLConf just to keep the test suite happy
 """
-from django.conf.urls import patterns
-
-urlpatterns = patterns('')
+urlpatterns = []

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,40 @@
-"""
-Blank URLConf just to keep the test suite happy
-"""
-urlpatterns = []
+from django.conf.urls import url
+from django.http import HttpResponse
+from rest_framework import permissions
+from rest_framework.views import APIView
+try:
+    from rest_framework_oauth.authentication import OAuth2Authentication
+except ImportError:
+    try:
+        from rest_framework.authentication import OAuth2Authentication
+    except ImportError:
+        OAuth2Authentication = None
+
+from rest_framework_jwt import views
+from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+
+
+class MockView(APIView):
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get(self, request):
+        return HttpResponse({'a': 1, 'b': 2, 'c': 3})
+
+    def post(self, request):
+        return HttpResponse({'a': 1, 'b': 2, 'c': 3})
+
+
+urlpatterns = [
+    url(r'^auth-token/$', views.obtain_jwt_token),
+    url(r'^auth-token-refresh/$', views.refresh_jwt_token),
+    url(r'^auth-token-verify/$', views.verify_jwt_token),
+
+    url(r'^jwt/$', MockView.as_view(
+        authentication_classes=[JSONWebTokenAuthentication])),
+    url(r'^jwt-oauth2/$', MockView.as_view(
+        authentication_classes=[
+            JSONWebTokenAuthentication, OAuth2Authentication])),
+    url(r'^oauth2-jwt/$', MockView.as_view(
+        authentication_classes=[
+            OAuth2Authentication, JSONWebTokenAuthentication])),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-django{1.8,1.9}-drf{3.0,3.1,3.2,3.3}
+       {py27,py33,py34}-django{1.8,1.9,1.10}-drf{3.0,3.1,3.2,3.3,3.4}
 
 [testenv]
 commands = ./runtests.py --fast {posargs}
@@ -10,12 +10,14 @@ setenv =
 deps =
        django1.8: Django==1.8.7
        django1.9: Django==1.9.0
+       django1.10: Django==1.10
        drf2.4: djangorestframework==2.4.5
        drf3.0: djangorestframework==3.0.5
        drf3.1: djangorestframework==3.1.3
        drf3.2: djangorestframework==3.2.2
        drf3.3: djangorestframework==3.3.2
-       py27-django{1.8,1.9}-drf{3.1,3.2,3.3}: djangorestframework-oauth==1.0.1
+       drf3.4: djangorestframework==3.4.6
+       py27-django{1.8,1.9,1.10}-drf{3.1,3.2,3.3,3.4}: djangorestframework-oauth==1.0.1
        -rrequirements/testing.txt
 
 [testenv:py27-flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
        {py27,py33,py34}-django{1.8,1.9,1.10}-drf{3.0,3.1,3.2,3.3,3.4}
 
 [testenv]
-commands = ./runtests.py --fast {posargs}
+commands = ./runtests.py --fast {posargs} --verbose
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
@@ -17,7 +17,7 @@ deps =
        drf3.2: djangorestframework==3.2.2
        drf3.3: djangorestframework==3.3.2
        drf3.4: djangorestframework==3.4.6
-       py27-django{1.8,1.9,1.10}-drf{3.1,3.2,3.3,3.4}: djangorestframework-oauth==1.0.1
+       py27-django{1.8,1.9}-drf{3.1,3.2,3.3}: djangorestframework-oauth==1.0.1
        -rrequirements/testing.txt
 
 [testenv:py27-flake8]


### PR DESCRIPTION
This branch takes a slightly different approach to 1.10/3.4 support than #252. It includes:

* Updated documentation indicating change in support.
* Add 1.10 and 3.4 to the Travis build matrix and tox file.
* Consolidates the test views into `tests/urls.py`. 1.10 wasn't working with `urlpatterns` in the `test_views` and `test_authentication` files.
* Tests the `is_active` behavior for the pre-1.10 `ModelBackend` and uses the new `AllowAllUsersModelBackend` to test the similar behavior for 1.10.
* Turns on `verbose` for tox execution to show what is skipped for Travis builds.

There is one oddity in this branch that I can't really explain well. `test_jwt_login_custom_response_json` did a check for the `username` with:

```python
self.assertEqual(response.data['user'], self.username)
```

That data did not exist under 1.10 and I don't understand why. Someone with a bit more history with the project might want to check if that's ok or a behavioral regression that needs to be fixed first.