### PR TITLE
Stop using django.conf.urls.patterns

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,12 +72,12 @@ In your `urls.py` add the following URL route to enable obtaining a token via a 
 from rest_framework_jwt.views import obtain_jwt_token
 #...
 
-urlpatterns = patterns(
+urlpatterns = [
     '',
     # ...
 
     url(r'^api-token-auth/', obtain_jwt_token),
-)
+]
 ```
 
 You can easily test if the endpoint is working by doing the following in your terminal, if you had a user created with the username **admin** and password **password123**.

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -2,7 +2,7 @@ import unittest
 
 from django.http import HttpResponse
 from django.test import TestCase
-from django.conf.urls import patterns
+from django.conf.urls import url
 
 from rest_framework import permissions, status
 try:
@@ -54,19 +54,18 @@ class MockView(APIView):
         return HttpResponse({'a': 1, 'b': 2, 'c': 3})
 
 
-urlpatterns = patterns(
-    '',
-    (r'^jwt/$', MockView.as_view(
-     authentication_classes=[JSONWebTokenAuthentication])),
+urlpatterns = [
+    url(r'^jwt/$', MockView.as_view(
+        authentication_classes=[JSONWebTokenAuthentication])),
 
-    (r'^jwt-oauth2/$', MockView.as_view(
+    url(r'^jwt-oauth2/$', MockView.as_view(
         authentication_classes=[
             JSONWebTokenAuthentication, OAuth2Authentication])),
 
-    (r'^oauth2-jwt/$', MockView.as_view(
+    url(r'^oauth2-jwt/$', MockView.as_view(
         authentication_classes=[
             OAuth2Authentication, JSONWebTokenAuthentication])),
-)
+]
 
 
 class JSONWebTokenAuthenticationTests(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -6,10 +6,11 @@ import time
 from django import get_version
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.conf.urls import patterns
+from django.conf.urls import url
 from rest_framework import status
 from rest_framework.test import APIClient
 
+import rest_framework_jwt.views
 from rest_framework_jwt import utils
 from rest_framework_jwt.compat import get_user_model
 from rest_framework_jwt.settings import api_settings, DEFAULTS
@@ -23,13 +24,11 @@ User = get_user_model()
 
 NO_CUSTOM_USER_MODEL = 'Custom User Model only supported after Django 1.5'
 
-urlpatterns = patterns(
-    '',
-    (r'^auth-token/$', 'rest_framework_jwt.views.obtain_jwt_token'),
-    (r'^auth-token-refresh/$', 'rest_framework_jwt.views.refresh_jwt_token'),
-    (r'^auth-token-verify/$', 'rest_framework_jwt.views.verify_jwt_token'),
-
-)
+urlpatterns = [
+    url(r'^auth-token/$', rest_framework_jwt.views.obtain_jwt_token),
+    url(r'^auth-token-refresh/$', rest_framework_jwt.views.refresh_jwt_token),
+    url(r'^auth-token-verify/$', rest_framework_jwt.views.verify_jwt_token),
+]
 
 orig_datetime = datetime
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,5 @@
 """
 Blank URLConf just to keep the test suite happy
 """
-from django.conf.urls import patterns
 
-urlpatterns = patterns('')
+urlpatterns = []


### PR DESCRIPTION
It is deprecated from Django 1.8
