### PR TITLE
Update of django, drf, python version handling in tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27-docs
 
-    - TOX_ENV=py27-django1.8-drf3.0
     - TOX_ENV=py27-django1.8-drf3.1
     - TOX_ENV=py27-django1.8-drf3.2
     - TOX_ENV=py27-django1.8-drf3.3
@@ -19,13 +18,11 @@ env:
 
     - TOX_ENV=py27-django1.10-drf3.4
 
-    - TOX_ENV=py33-django1.8-drf3.0
     - TOX_ENV=py33-django1.8-drf3.1
     - TOX_ENV=py33-django1.8-drf3.2
     - TOX_ENV=py33-django1.8-drf3.3
     - TOX_ENV=py33-django1.8-drf3.4
 
-    - TOX_ENV=py34-django1.8-drf3.0
     - TOX_ENV=py34-django1.8-drf3.1
     - TOX_ENV=py34-django1.8-drf3.2
     - TOX_ENV=py34-django1.8-drf3.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,21 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-django{1.8,1.9,1.10}-drf{3.0,3.1,3.2,3.3,3.4}
+       {py27,py33,py34}-django{1.8,1.9,1.10}-drf{3.1,3.2,3.3,3.4}
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --verbose
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.8: Django==1.8.7
-       django1.9: Django==1.9.0
-       django1.10: Django==1.10
-       drf2.4: djangorestframework==2.4.5
-       drf3.0: djangorestframework==3.0.5
-       drf3.1: djangorestframework==3.1.3
-       drf3.2: djangorestframework==3.2.2
-       drf3.3: djangorestframework==3.3.2
-       drf3.4: djangorestframework==3.4.6
-       py27-django{1.8,1.9}-drf{3.1,3.2,3.3}: djangorestframework-oauth==1.0.1
+       django1.8: Django<1.9
+       django1.9: Django<1.10
+       django1.10: Django<1.11
+       drf3.1: djangorestframework<3.2
+       drf3.2: djangorestframework<3.3
+       drf3.3: djangorestframework<3.4
+       drf3.4: djangorestframework<3.5
+       py27-django{1.8,1.9}-drf{3.1,3.2,3.3,3.4}: djangorestframework-oauth==1.0.1
        -rrequirements/testing.txt
 
 [testenv:py27-flake8]


### PR DESCRIPTION
- Removed tests for drf 2.4, 3.0 because django versions 1.8,1.9,1.10 doesn't play well with them.
- Untie drf and django to specific releases for a version, and instead get the latest release of every version

Some of these changes were done in #252 but weren't merged because #256 was more complete adding support of drf3.4 and django 1.10, however I rather like to test against the latest release of a version so this is the main motivation of this PR.

Regards.
