### PR TITLE
Allow jtw_payload_handler to work with User models that don't have an Email field

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -20,10 +20,11 @@ def jwt_payload_handler(user):
 
     payload = {
         'user_id': user.pk,
-        'email': user.email,
         'username': username,
         'exp': datetime.utcnow() + api_settings.JWT_EXPIRATION_DELTA
     }
+    if hasattr(user, 'email'):
+        payload['email'] = user.email
     if isinstance(user.pk, uuid.UUID):
         payload['user_id'] = str(user.pk)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -14,6 +14,17 @@ class CustomUser(AbstractBaseUser):
         app_label = 'tests'
 
 
+class CustomUserWithoutEmail(AbstractBaseUser):
+    username = models.CharField(max_length=255, unique=True)
+
+    objects = BaseUserManager()
+
+    USERNAME_FIELD = 'username'
+
+    class Meta:
+        app_label = 'tests'
+
+
 class CustomUserUUID(AbstractBaseUser):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     email = models.EmailField(max_length=255, unique=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from rest_framework_jwt import utils
 from rest_framework_jwt.compat import get_user_model
 from rest_framework_jwt.settings import api_settings, DEFAULTS
+from tests.models import CustomUserWithoutEmail
 
 User = get_user_model()
 
@@ -35,6 +36,16 @@ class UtilsTests(TestCase):
         self.assertTrue(isinstance(payload, dict))
         self.assertEqual(payload['user_id'], self.user.pk)
         self.assertEqual(payload['email'], self.email)
+        self.assertEqual(payload['username'], self.username)
+        self.assertTrue('exp' in payload)
+
+    def test_jwt_payload_handler_no_email_address(self):
+        user = CustomUserWithoutEmail.objects.create(username=self.username)
+
+        payload = utils.jwt_payload_handler(user)
+        self.assertTrue(isinstance(payload, dict))
+        self.assertFalse(hasattr(payload, 'email'))
+        self.assertEqual(payload['user_id'], self.user.pk)
         self.assertEqual(payload['username'], self.username)
         self.assertTrue('exp' in payload)
 


### PR DESCRIPTION
I'm using a custom User model that doesn't have an email field. I've made the inclusion of the email field optional in jwt_payload_handler based on whether the attr exists on the model object.
