### PR TITLE
Upgrade cryptography requirement

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,4 +4,4 @@ pytest-django==2.8.0
 pytest-cov==1.6
 
 # Mocking the datetime module.
-cryptography==1.2.2
+cryptography==1.2.3


### PR DESCRIPTION
Fix installation of test requirements, with latest openSSL version:
https://github.com/pyca/cryptography/issues/2750
