### PR TITLE
Fix refresh tokens

### DIFF
--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -169,3 +169,27 @@ class RefreshJSONWebTokenSerializer(VerificationBaseSerializer):
             'token': jwt_encode_handler(new_payload),
             'user': user
         }
+
+    def _check_payload(self, token):
+        # Check payload valid, but exp
+        # TODO: a jwt_decode_handler with a verify_exp option?
+        options = {
+            'verify_exp': False
+        }
+        try:
+            payload = jwt.decode(
+                token,
+                api_settings.JWT_PUBLIC_KEY or api_settings.JWT_SECRET_KEY,
+                api_settings.JWT_VERIFY,
+                options=options,
+                leeway=api_settings.JWT_LEEWAY,
+                audience=api_settings.JWT_AUDIENCE,
+                issuer=api_settings.JWT_ISSUER,
+                algorithms=[api_settings.JWT_ALGORITHM]
+            )
+        except jwt.DecodeError:
+            msg = _('Error decoding signature.')
+            raise serializers.ValidationError(msg)
+
+        return payload
+

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -16,6 +16,7 @@ User = get_user_model()
 jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
 jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
 jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
+jwt_refresh_decode_handler = api_settings.JWT_REFRESH_DECODE_HANDLER
 jwt_get_username_from_payload = api_settings.JWT_PAYLOAD_GET_USERNAME_HANDLER
 
 
@@ -171,22 +172,8 @@ class RefreshJSONWebTokenSerializer(VerificationBaseSerializer):
         }
 
     def _check_payload(self, token):
-        # Check payload valid, but exp
-        # TODO: a jwt_decode_handler with a verify_exp option?
-        options = {
-            'verify_exp': False
-        }
         try:
-            payload = jwt.decode(
-                token,
-                api_settings.JWT_PUBLIC_KEY or api_settings.JWT_SECRET_KEY,
-                api_settings.JWT_VERIFY,
-                options=options,
-                leeway=api_settings.JWT_LEEWAY,
-                audience=api_settings.JWT_AUDIENCE,
-                issuer=api_settings.JWT_ISSUER,
-                algorithms=[api_settings.JWT_ALGORITHM]
-            )
+            payload = jwt_refresh_decode_handler(token)
         except jwt.DecodeError:
             msg = _('Error decoding signature.')
             raise serializers.ValidationError(msg)

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -192,4 +192,3 @@ class RefreshJSONWebTokenSerializer(VerificationBaseSerializer):
             raise serializers.ValidationError(msg)
 
         return payload
-

--- a/rest_framework_jwt/settings.py
+++ b/rest_framework_jwt/settings.py
@@ -13,6 +13,9 @@ DEFAULTS = {
     'JWT_DECODE_HANDLER':
     'rest_framework_jwt.utils.jwt_decode_handler',
 
+    'JWT_REFRESH_DECODE_HANDLER':
+    'rest_framework_jwt.utils.jwt_refresh_decode_handler',
+
     'JWT_PAYLOAD_HANDLER':
     'rest_framework_jwt.utils.jwt_payload_handler',
 
@@ -50,6 +53,7 @@ DEFAULTS = {
 IMPORT_STRINGS = (
     'JWT_ENCODE_HANDLER',
     'JWT_DECODE_HANDLER',
+    'JWT_REFRESH_DECODE_HANDLER',
     'JWT_PAYLOAD_HANDLER',
     'JWT_PAYLOAD_GET_USER_ID_HANDLER',
     'JWT_PAYLOAD_GET_USERNAME_HANDLER',

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -77,7 +77,17 @@ def jwt_decode_handler(token):
     options = {
         'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
     }
+    return jwt_decode(token, options)
 
+
+def jwt_refresh_decode_handler(token):
+    options = {
+        'verify_exp': False
+    }
+    return jwt_decode(token, options)
+
+
+def jwt_decode(token, options):
     return jwt.decode(
         token,
         api_settings.JWT_PUBLIC_KEY or api_settings.JWT_SECRET_KEY,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -514,7 +514,6 @@ class RefreshJSONWebTokenTests(TokenTestCase):
         self.assertEqual(response.data['non_field_errors'][0],
                          'Refresh has expired.')
 
-
     def tearDown(self):
         # Restore original settings
         api_settings.JWT_ALLOW_REFRESH = DEFAULTS['JWT_ALLOW_REFRESH']

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -469,6 +469,31 @@ class RefreshJSONWebTokenTests(TokenTestCase):
         self.assertEquals(new_token_decoded['orig_iat'], orig_iat)
         self.assertGreater(new_token_decoded['exp'], orig_token_decoded['exp'])
 
+    def test_refresh_jwt_after_expiration(self):
+        client = APIClient(enforce_csrf_checks=True)
+
+        # Make an refreshable, expired token..
+        orig_iat = datetime.utcnow() - timedelta(hours=1)
+        exp = datetime.utcnow() - timedelta(seconds=5)
+        token = self.create_token(
+            self.user,
+            exp=exp,
+            orig_iat=orig_iat
+        )
+
+        response = client.post('/auth-token-refresh/', {'token': token},
+                               format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        new_token = response.data['token']
+        new_token_decoded = utils.jwt_decode_handler(new_token)
+
+        # Make sure 'orig_iat' on the new token is same as original
+        self.assertEquals(new_token_decoded['orig_iat'],
+                          timegm(orig_iat.utctimetuple()))
+        self.assertGreater(new_token_decoded['exp'],
+                           timegm(exp.utctimetuple()))
+
     def test_refresh_jwt_after_refresh_expiration(self):
         """
         Test that token can't be refreshed after token refresh limit
@@ -488,6 +513,7 @@ class RefreshJSONWebTokenTests(TokenTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data['non_field_errors'][0],
                          'Refresh has expired.')
+
 
     def tearDown(self):
         # Restore original settings


### PR DESCRIPTION
Trying to get an new token, with an 'expired' token results in an
signature error. The token is decoded with verification of 'exp' claim.
Only the orig_iat claim should be verified in this case.

Problem is the JWT_DECODE_HANDLER does not have an option to disable exp verification.
Changing the default handler would be an backwards incompatible change... not sure how you guys would want to handle that.
So in this pull it has it's own call to jwt.encode...

Fixes #249
