### PR TITLE
Allow using a cookie as a transport for the token

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -177,6 +177,7 @@ JWT_AUTH = {
     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
+    'JWT_AUTH_COOKIE': None,
 }
 ```
 This packages uses the JSON Web Token Python implementation, [PyJWT](https://github.com/jpadilla/pyjwt) and allows to modify some of it's available options.
@@ -276,9 +277,18 @@ Another common value used for tokens and Authorization headers is `Bearer`.
 
 Default is `JWT`.
 
+### JWT_AUTH_COOKIE
+You can set this to a string if you want to use http cookies in addition to the Authorization header as a valid transport for the token.
+The string you set here will be used as the cookie name that will be set in the response headers when requesting a token. The token validation
+procedure will also look into this cookie, if set. The 'Authorization' header takes precedence if both the header and the cookie are present in the request.
+
+Another common value used for tokens and Authorization headers is `Bearer`.
+
+Default is `None` and no cookie is set when creating tokens nor accepted when validating them.
+
 ## Extending `JSONWebTokenAuthentication`
 
-Right now `JSONWebTokenAuthentication` assumes that the JWT will come in the header. The JWT spec does not require this (see: [Making a service Call](https://developer.atlassian.com/static/connect/docs/concepts/authentication.html)). For example, the JWT may come in the querystring. The ability to send the JWT in the querystring is needed in cases where the user cannot set the header (for example the src element in HTML).
+Right now `JSONWebTokenAuthentication` assumes that the JWT will come in the header, or a cookie if configured (see [JWT_AUTH_COOKIE](#JWT_AUTH_COOKIE)). The JWT spec does not require this (see: [Making a service Call](https://developer.atlassian.com/static/connect/docs/concepts/authentication.html)). For example, the JWT may come in the querystring. The ability to send the JWT in the querystring is needed in cases where the user cannot set the header (for example the src element in HTML).
 
 To achieve this functionality, the user might write a custom `Authentication`:
 ```python

--- a/rest_framework_jwt/authentication.py
+++ b/rest_framework_jwt/authentication.py
@@ -82,7 +82,12 @@ class JSONWebTokenAuthentication(BaseJSONWebTokenAuthentication):
         auth = get_authorization_header(request).split()
         auth_header_prefix = api_settings.JWT_AUTH_HEADER_PREFIX.lower()
 
-        if not auth or smart_text(auth[0].lower()) != auth_header_prefix:
+        if not auth:
+            if api_settings.JWT_AUTH_COOKIE:
+                return request.COOKIES.get(api_settings.JWT_AUTH_COOKIE)
+            return None
+
+        if smart_text(auth[0].lower()) != auth_header_prefix:
             return None
 
         if len(auth) == 1:

--- a/rest_framework_jwt/settings.py
+++ b/rest_framework_jwt/settings.py
@@ -44,6 +44,7 @@ DEFAULTS = {
     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
+    'JWT_AUTH_COOKIE': None,
 }
 
 # List of settings that may be in string import notation.


### PR DESCRIPTION
A new configuration 'JWT_AUTH_COOKIE' has been added. If it set
to None (the default), everything works the same.

It can be set to a string to use as the name of the cookie that
can be used to carry the token. Note the 'Authorization' header is
still accepted as the primary method, but it falls back to the
designated cookie if present.

When a token is requested and 'JWT_AUTH_COOKIE' is set, the response
will set the given cookie with the token string.

Fix #120
