### PR TITLE
Catch AttributeError

### DIFF
--- a/rest_framework_jwt/compat.py
+++ b/rest_framework_jwt/compat.py
@@ -22,7 +22,7 @@ class PasswordField(serializers.CharField):
 def get_username_field():
     try:
         username_field = get_user_model().USERNAME_FIELD
-    except:
+    except AttributeError:
         username_field = 'username'
 
     return username_field


### PR DESCRIPTION
No named exception was handled in the get_username_field method. This fix catches the AttributeError.
