### PR TITLE
Use get_username_field to determine username field on payload

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -62,7 +62,8 @@ def jwt_get_username_from_payload_handler(payload):
     """
     Override this function if username is formatted differently in payload
     """
-    return payload.get('username')
+    username_field = get_username_field()
+    return payload.get(username_field)
 
 
 def jwt_encode_handler(payload):


### PR DESCRIPTION
Fixes #284.

I think this is a more sensible default for the `jwt_get_username_from_payload_handler()`