### PR TITLE
Add support for python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+python: '3.5'
+
 language: python
 
 sudo: false
@@ -44,6 +46,9 @@ env:
 
     - TOX_ENV=py34-django1.10-drf3.4
     - TOX_ENV=py34-django1.10-drf3.5
+
+    - TOX_ENV=py35-django1.10-drf3.4
+    - TOX_ENV=py35-django1.10-drf3.5
 
 matrix:
   fast_finish: true

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ If you want to know more about JWT, check out the following resources:
 Requirements
 ------------
 
--  Python (2.7, 3.3, 3.4)
+-  Python (2.7, 3.3, 3.4, 3.5)
 -  Django (1.8, 1.9, 1.10)
 -  Django REST Framework (3.0, 3.1, 3.2, 3.3, 3.4, 3.5)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ If you want to know more about JWT, check out the following resources:
 
 ## Requirements
 
-- Python (2.7, 3.3, 3.4)
+- Python (2.7, 3.3, 3.4, 3.5)
 - Django (1.8, 1.9, 1.10)
 - Django REST Framework (3.0, 3.1, 3.2, 3.3, 3.4, 3.5)
 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-django{1.8,1.9,1.10}-drf{3.0,3.1,3.2,3.3,3.4,3.5}
+       {py27,py33,py34,py35}-django{1.8,1.9,1.10}-drf{3.0,3.1,3.2,3.3,3.4,3.5}
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --verbose


### PR DESCRIPTION
In order to make drf and drf-jwt more consistent let's add testing on python 3.5