### PR TITLE
Add request parameter to jwt_decode_handler (fixes #243)

### DIFF
--- a/rest_framework_jwt/authentication.py
+++ b/rest_framework_jwt/authentication.py
@@ -1,3 +1,5 @@
+import inspect
+
 import jwt
 
 from django.contrib.auth import get_user_model
@@ -11,7 +13,6 @@ from rest_framework.authentication import (
 from rest_framework_jwt.settings import api_settings
 
 
-jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
 jwt_get_username_from_payload = api_settings.JWT_PAYLOAD_GET_USERNAME_HANDLER
 
 
@@ -29,8 +30,14 @@ class BaseJSONWebTokenAuthentication(BaseAuthentication):
         if jwt_value is None:
             return None
 
+        jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
+        num_args = len(inspect.getargs(jwt_decode_handler.__code__).args)
+        kwargs = {}
+        if num_args == 2:
+            kwargs["request"] = request
+
         try:
-            payload = jwt_decode_handler(jwt_value)
+            payload = jwt_decode_handler(jwt_value, **kwargs)
         except jwt.ExpiredSignature:
             msg = _('Signature has expired.')
             raise exceptions.AuthenticationFailed(msg)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -25,6 +25,7 @@ except ImportError:
         # because models have not been initialized.
         oauth2_provider = None
 
+from rest_framework.request import Request
 from rest_framework.test import APIClient
 from rest_framework.test import APIRequestFactory
 
@@ -76,6 +77,35 @@ class JSONWebTokenAuthenticationTests(TestCase):
             '/jwt/', {'example': 'example'},
             HTTP_AUTHORIZATION=auth, format='json')
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_post_json_passing_jwt_auth_and_request(self):
+        """
+        Ensure POSTing JSON over JWT auth with correct credentials
+        passes and does not require CSRF, and that request is passed to
+        jwt_decode_handler when available
+        """
+        payload = utils.jwt_payload_handler(self.user)
+        token = utils.jwt_encode_handler(payload)
+
+        request_is_available = {'value': False}
+        _jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
+
+        def jwt_decode_handler(jwt_value, request):
+            if isinstance(request, Request):
+                request_is_available['value'] = True
+            return _jwt_decode_handler(jwt_value)
+
+        api_settings.JWT_DECODE_HANDLER = jwt_decode_handler
+
+        auth = 'JWT {0}'.format(token)
+        response = self.csrf_client.post(
+            '/jwt/', {'example': 'example'},
+            HTTP_AUTHORIZATION=auth, format='json')
+
+        api_settings.JWT_DECODE_HANDLER = _jwt_decode_handler
+
+        self.assertEqual(request_is_available, {'value': True})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_post_form_failing_jwt_auth(self):


### PR DESCRIPTION
Currently only the `jwt_token` is passed to the `jwt_decode_handler`. This pull request adds the `request` parameter if `jwt_decode_handler` throws a `TypeError` while being called with only one parameter (which happens if `jwt_decode_handler` takes more than one parameter).
