### PR TITLE
Replace login with log in when used as a verb

### DIFF
--- a/rest_framework_jwt/locale/en_US/LC_MESSAGES/django.po
+++ b/rest_framework_jwt/locale/en_US/LC_MESSAGES/django.po
@@ -47,7 +47,7 @@ msgid "User account is disabled."
 msgstr ""
 
 #: serializers.py:76
-msgid "Unable to login with provided credentials."
+msgid "Unable to log in with provided credentials."
 msgstr ""
 
 #: serializers.py:79

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -61,7 +61,7 @@ class JSONWebTokenSerializer(Serializer):
                     'user': user
                 }
             else:
-                msg = _('Unable to login with provided credentials.')
+                msg = _('Unable to log in with provided credentials.')
                 raise serializers.ValidationError(msg)
         else:
             msg = _('Must include "{username_field}" and "password".')

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -64,7 +64,7 @@ class JSONWebTokenSerializerTests(TestCase):
         is_valid = serializer.is_valid()
 
         expected_error = {
-            'non_field_errors': ['Unable to login with provided credentials.']
+            'non_field_errors': ['Unable to log in with provided credentials.']
         }
 
         self.assertFalse(is_valid)


### PR DESCRIPTION
Per [issue 294](https://github.com/GetBlimp/django-rest-framework-jwt/issues/294) this change changes 'login' to 'log in' when the phrase is used as a verb.