### PR TITLE
Add support for different credential types (Fixes #296)

### DIFF
--- a/rest_framework_jwt/credentials.py
+++ b/rest_framework_jwt/credentials.py
@@ -1,0 +1,21 @@
+from rest_framework import serializers
+from .compat import get_username_field, PasswordField
+from django.utils.translation import ugettext as _
+
+
+class BasicCredentials(object):
+    """
+    Basic Credentials expects username and password fields.
+
+    """
+    @property
+    def fields(self):
+        fields = dict()
+        fields[get_username_field()] = serializers.CharField()
+        fields['password'] = PasswordField(write_only=True)
+        return fields
+
+    @property
+    def validation_message(self):
+        msg = _('Must include "{username_field}" and "password".')
+        return msg.format(username_field=get_username_field())

--- a/rest_framework_jwt/settings.py
+++ b/rest_framework_jwt/settings.py
@@ -3,6 +3,7 @@ import datetime
 from django.conf import settings
 from rest_framework.settings import APISettings
 
+from .credentials import BasicCredentials
 
 USER_SETTINGS = getattr(settings, 'JWT_AUTH', None)
 
@@ -44,7 +45,10 @@ DEFAULTS = {
     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
+
+    'JWT_CREDENTIALS': BasicCredentials,
 }
+
 
 # List of settings that may be in string import notation.
 IMPORT_STRINGS = (


### PR DESCRIPTION
Currently, rest-framework-jwt only supports authentication with username and password. This fixes this behavior by adding support for custom credential classes.