### PR TITLE
Don't require the 'token' key to override jwt_response_payload_handler

### DIFF
--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -63,7 +63,7 @@ class JSONWebTokenAPIView(APIView):
                 expiration = (datetime.utcnow() +
                               api_settings.JWT_EXPIRATION_DELTA)
                 response.set_cookie(api_settings.JWT_AUTH_COOKIE,
-                                    response.data['token'],
+                                    token,
                                     expires=expiration,
                                     httponly=True)
             return response


### PR DESCRIPTION
If you have JWT_AUTH_COOKIE enabled and you cannot override jwt_response_payload_handler with your own implementation that does not include the "token" key. This small change uses the token as you already have it rather than the trying to retrieve it from the response data