### PR TITLE
Allow token-cookie to be cross-domain

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -179,6 +179,7 @@ JWT_AUTH = {
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
     'JWT_AUTH_COOKIE': None,
+    'JWT_AUTH_COOKIE_DOMAIN': None,
 
 }
 ```
@@ -291,6 +292,11 @@ The string you set here will be used as the cookie name that will be set in the 
 procedure will also look into this cookie, if set. The 'Authorization' header takes precedence if both the header and the cookie are present in the request.
 
 Default is `None` and no cookie is set when creating tokens nor accepted when validating them.
+
+## JWT_AUTH_COOKIE_DOMAIN
+You can set this string if you want `JWT_AUTH_COOKIE` to be a cross-domain cookie. For example, `JWT_AUTH_COOKIE_DOMAIN : '.example.com'` will set a cookie that is readable by example.com and its sub-domains (blogs.example.com and calendars.lawrence.com, etc).
+
+Default is `None`, which means that `JWT_AUTH_COOKIE` will readable only to the domain that set it. If `JWT_AUTH_COOKIE` is `None`, setting `JWT_AUTH_COOKIE_DOMAIN` does nothing.
 
 ## Extending `JSONWebTokenAuthentication`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -296,7 +296,7 @@ Default is `None` and no cookie is set when creating tokens nor accepted when va
 ## JWT_AUTH_COOKIE_DOMAIN
 You can set this string if you want `JWT_AUTH_COOKIE` to be a cross-domain cookie. For example, `JWT_AUTH_COOKIE_DOMAIN : '.example.com'` will set a cookie that is readable by example.com and its sub-domains (blogs.example.com and calendars.lawrence.com, etc).
 
-Default is `None`, which means that `JWT_AUTH_COOKIE` will readable only to the domain that set it. If `JWT_AUTH_COOKIE` is `None`, setting `JWT_AUTH_COOKIE_DOMAIN` does nothing.
+Default is `None`, which means that `JWT_AUTH_COOKIE` will be readable only to the domain that set it. If `JWT_AUTH_COOKIE` is `None`, setting `JWT_AUTH_COOKIE_DOMAIN` does nothing.
 
 ## Extending `JSONWebTokenAuthentication`
 

--- a/rest_framework_jwt/settings.py
+++ b/rest_framework_jwt/settings.py
@@ -46,6 +46,7 @@ DEFAULTS = {
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
     'JWT_AUTH_COOKIE': None,
+    'JWT_AUTH_COOKIE_DOMAIN': None,
 }
 
 # List of settings that may be in string import notation.

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -65,7 +65,8 @@ class JSONWebTokenAPIView(APIView):
                 response.set_cookie(api_settings.JWT_AUTH_COOKIE,
                                     token,
                                     expires=expiration,
-                                    httponly=True)
+                                    httponly=True,
+                                    domain=api_settings.JWT_AUTH_COOKIE_DOMAIN)
             return response
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Addresses #258. Example use case:

 Support for Api servers on one sub domain (api.example.com) and web servers on a another (app.example.com).