### PR TITLE
The verify argument is deprecated in jwt.decode

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -98,15 +98,16 @@ def jwt_encode_handler(payload):
 
 def jwt_decode_handler(token):
     options = {
+        'verify_signature': api_settings.JWT_VERIFY,
         'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
     }
     # get user from token, BEFORE verification, to get user secret key
-    unverified_payload = jwt.decode(token, None, False)
+    unverified_payload = jwt.decode(token, None, options={
+        'verify_signature': False})
     secret_key = jwt_get_secret_key(unverified_payload)
     return jwt.decode(
         token,
         api_settings.JWT_PUBLIC_KEY or secret_key,
-        api_settings.JWT_VERIFY,
         options=options,
         leeway=api_settings.JWT_LEEWAY,
         audience=api_settings.JWT_AUDIENCE,


### PR DESCRIPTION
This uses the "verify_signature" option instead.