### PR TITLE
Optimization of DB queries when decoding token with per user secret.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ python: '3.5'
 
 language: python
 
+dist: precise
+
 cache: pip
 sudo: false
 

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -23,7 +23,6 @@ def jwt_get_secret_key(payload=None):
     """
     if api_settings.JWT_GET_USER_SECRET_KEY:
         User = get_user_model()  # noqa: N806
-        payload.get('username')
         user = User.objects.get_by_natural_key(payload.get('username'))
         key = str(api_settings.JWT_GET_USER_SECRET_KEY(user))
         return key

--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -23,7 +23,8 @@ def jwt_get_secret_key(payload=None):
     """
     if api_settings.JWT_GET_USER_SECRET_KEY:
         User = get_user_model()  # noqa: N806
-        user = User.objects.get(pk=payload.get('user_id'))
+        payload.get('username')
+        user = User.objects.get_by_natural_key(payload.get('username'))
         key = str(api_settings.JWT_GET_USER_SECRET_KEY(user))
         return key
     return api_settings.JWT_SECRET_KEY

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34,py35}-django{1.8,1.9,1.10,1.11}-drf{3.1,3.2,3.3,3.4,3.5,3.6}
+       {py27,py33,py34,py35,py36}-django{1.8,1.9,1.10,1.11}-drf{3.1,3.2,3.3,3.4,3.5,3.6}
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --verbose


### PR DESCRIPTION
When using token secret on user, DB is called twice to decode token:
* once by id to get secret
* second time by natural key in "authenticate_credentials"
Because of two different keys used to call DB this database query was hard to cache.
The code was changed to use "get_by_natural_key" in both cases.

Other improvements:
* added py36 in travis - this works
* set travis to use "precise" as default distribution, otherwise tests fails.
