### PR TITLE
setting JWT_PAYLOAD_GET_USER_ID_HANDLER ignored

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -23,7 +23,7 @@ def jwt_get_secret_key(payload=None):
     """
     if api_settings.JWT_GET_USER_SECRET_KEY:
         User = get_user_model()  # noqa: N806
-        user = User.objects.get(pk=payload.get('user_id'))
+        user = User.objects.get(pk=api_settings.JWT_PAYLOAD_GET_USER_ID_HANDLER(payload))
         key = str(api_settings.JWT_GET_USER_SECRET_KEY(user))
         return key
     return api_settings.JWT_SECRET_KEY


### PR DESCRIPTION
User_id is read directly from payload leading to problems when using custom encoding on user_id field. Trivial fix: use api_settings.JWT_PAYLOAD_GET_USER_ID_HANDLER instead of payload.get('user_id').
Fixes issue #379