### PR TITLE
tests: fix MockView

### DIFF
--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -62,6 +62,7 @@ class JSONWebTokenAuthenticationTests(TestCase):
             '/jwt/', {'example': 'example'}, HTTP_AUTHORIZATION=auth)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content, b'mockview-post')
 
     def test_post_json_passing_jwt_auth(self):
         """

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -18,10 +18,10 @@ class MockView(APIView):
     permission_classes = (permissions.IsAuthenticated,)
 
     def get(self, request):
-        return HttpResponse({'a': 1, 'b': 2, 'c': 3})
+        return HttpResponse('mockview-get')
 
     def post(self, request):
-        return HttpResponse({'a': 1, 'b': 2, 'c': 3})
+        return HttpResponse('mockview-post')
 
 
 urlpatterns = [


### PR DESCRIPTION
It should use a (byte) string.
Using a dict here results in the keys being used, but in an
unpredictable order.