### PR TITLE
jwt_get_secret_key check if user exists

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -23,9 +23,12 @@ def jwt_get_secret_key(payload=None):
     """
     if api_settings.JWT_GET_USER_SECRET_KEY:
         User = get_user_model()  # noqa: N806
-        user = User.objects.get(pk=payload.get('user_id'))
-        key = str(api_settings.JWT_GET_USER_SECRET_KEY(user))
-        return key
+        try:
+            user = User.objects.get(pk=payload.get('user_id'))
+            key = str(api_settings.JWT_GET_USER_SECRET_KEY(user))
+            return key
+        except User.DoesNotExist:
+            pass
     return api_settings.JWT_SECRET_KEY
 
 


### PR DESCRIPTION
When a user with a deleted account tries to access the website with a JWT that is still valid, it causes an error 500. This checks if the user with the given pk exists, and if a user not, it will return the `api_settings.JWT_SECRET_KEY` instead of the deleted user's secret key