### PR TITLE
Fixing authentication

### DIFF
--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -47,7 +47,7 @@ class JSONWebTokenSerializer(Serializer):
         }
 
         if all(credentials.values()):
-            user = authenticate(**credentials)
+            user = authenticate(request=self.context['request], **credentials)
 
             if user:
                 if not user.is_active:

--- a/rest_framework_jwt/serializers.py
+++ b/rest_framework_jwt/serializers.py
@@ -47,7 +47,7 @@ class JSONWebTokenSerializer(Serializer):
         }
 
         if all(credentials.values()):
-            user = authenticate(request=self.context['request], **credentials)
+            user = authenticate(request=self.context['request'], **credentials)
 
             if user:
                 if not user.is_active:


### PR DESCRIPTION
not sending a request object is deprecated since Django 1.11 and this also broke Django Axes .. since the request is already in the context, thats an easy fix