### PR TITLE
Use get_by_natural_key in jwt_get_secret_key

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -23,7 +23,9 @@ def jwt_get_secret_key(payload=None):
     """
     if api_settings.JWT_GET_USER_SECRET_KEY:
         User = get_user_model()  # noqa: N806
-        user = User.objects.get(pk=payload.get('user_id'))
+        username_field = get_username_field()
+        username = payload.get(username_field)
+        user = User.objects.get_by_natural_key(username)
         key = str(api_settings.JWT_GET_USER_SECRET_KEY(user))
         return key
     return api_settings.JWT_SECRET_KEY


### PR DESCRIPTION
As stated in commit `a3b4d44d2fc34d7752793ccbade2684707bf41da`, the field `user_id` in payload will be deprecated.

Instead of explicitly using `user_id` field to retrieve user in `utils.jwt_get_secret_key` function, we should use `User.objects.get_by_natural_key` with the value in the payload dictionary at `username_field` key.