### PR TITLE
Optional user based secret key

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -21,7 +21,7 @@ def jwt_get_secret_key(payload=None):
         - password is changed
         - etc.
     """
-    if api_settings.JWT_GET_USER_SECRET_KEY:
+    if api_settings.JWT_GET_USER_SECRET_KEY and 'user_id' in payload:
         User = get_user_model()  # noqa: N806
         user = User.objects.get(pk=payload.get('user_id'))
         key = str(api_settings.JWT_GET_USER_SECRET_KEY(user))


### PR DESCRIPTION
Use `JWT_GET_USER_SECRET_KEY` only when you actually pass `user_id` in the `payload`.

This way you are able to use user-based secret keys and fallback to a default secret key when user is irrelevant.

Also, without this check, you will be getting `DoesNotExist` error when trying to generate a token for payload without `user_id`.