### PR TITLE
Adding test support for Django 2.0 / DRF 3.7, 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,135 +5,135 @@ cache: pip
 matrix:
   fast_finish: true
   include:
-    # - python: 2.7
-    #   env: TOXENV=py27-flake8
-    # - python: 2.7
-    #   env: TOXENV=py27-docs
+    - python: 2.7
+      env: TOXENV=py27-flake8
+    - python: 2.7
+      env: TOXENV=py27-docs
 
-    # - python: 2.7
-    #   env: TOXENV=py27-dj18-drf31-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj18-drf32-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj18-drf33-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj18-drf34-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj18-drf35-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj18-drf36-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj18-drf31-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj18-drf32-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj18-drf33-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj18-drf34-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj18-drf35-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj18-drf36-codecov
 
-    # - python: 2.7
-    #   env: TOXENV=py27-dj19-drf31-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj19-drf32-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj19-drf33-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj19-drf34-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj19-drf35-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj19-drf36-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj19-drf31-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj19-drf32-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj19-drf33-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj19-drf34-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj19-drf35-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj19-drf36-codecov
 
-    # - python: 2.7
-    #   env: TOXENV=py27-dj110-drf34-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj110-drf35-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj110-drf36-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj110-drf34-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj110-drf35-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj110-drf36-codecov
 
-    # - python: 2.7
-    #   env: TOXENV=py27-dj111-drf34-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj111-drf35-codecov
-    # - python: 2.7
-    #   env: TOXENV=py27-dj111-drf36-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj111-drf34-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj111-drf35-codecov
+    - python: 2.7
+      env: TOXENV=py27-dj111-drf36-codecov
 
-    # - python: 3.3
-    #   env: TOXENV=py33-dj18-drf31-codecov
-    # - python: 3.3
-    #   env: TOXENV=py33-dj18-drf32-codecov
-    # - python: 3.3
-    #   env: TOXENV=py33-dj18-drf33-codecov
-    # - python: 3.3
-    #   env: TOXENV=py33-dj18-drf34-codecov
-    # - python: 3.3
-    #   env: TOXENV=py33-dj18-drf35-codecov
-    # - python: 3.3
-    #   env: TOXENV=py33-dj18-drf36-codecov
+    - python: 3.3
+      env: TOXENV=py33-dj18-drf31-codecov
+    - python: 3.3
+      env: TOXENV=py33-dj18-drf32-codecov
+    - python: 3.3
+      env: TOXENV=py33-dj18-drf33-codecov
+    - python: 3.3
+      env: TOXENV=py33-dj18-drf34-codecov
+    - python: 3.3
+      env: TOXENV=py33-dj18-drf35-codecov
+    - python: 3.3
+      env: TOXENV=py33-dj18-drf36-codecov
 
-    # - python: 3.4
-    #   env: TOXENV=py34-dj18-drf31-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj18-drf32-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj18-drf33-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj18-drf34-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj18-drf35-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj18-drf36-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj18-drf31-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj18-drf32-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj18-drf33-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj18-drf34-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj18-drf35-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj18-drf36-codecov
 
-    # - python: 3.4
-    #   env: TOXENV=py34-dj19-drf31-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj19-drf32-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj19-drf33-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj19-drf34-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj19-drf35-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj19-drf36-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj19-drf31-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj19-drf32-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj19-drf33-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj19-drf34-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj19-drf35-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj19-drf36-codecov
 
-    # - python: 3.4
-    #   env: TOXENV=py34-dj110-drf34-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj110-drf35-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj110-drf36-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj110-drf34-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj110-drf35-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj110-drf36-codecov
 
-    # - python: 3.4
-    #   env: TOXENV=py34-dj111-drf34-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj111-drf35-codecov
-    # - python: 3.4
-    #   env: TOXENV=py34-dj111-drf36-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj111-drf34-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj111-drf35-codecov
+    - python: 3.4
+      env: TOXENV=py34-dj111-drf36-codecov
 
-    # - python: 3.5
-    #   env: TOXENV=py35-dj110-drf34-codecov
-    # - python: 3.5
-    #   env: TOXENV=py35-dj110-drf35-codecov
-    # - python: 3.5
-    #   env: TOXENV=py35-dj110-drf36-codecov
+    - python: 3.5
+      env: TOXENV=py35-dj110-drf34-codecov
+    - python: 3.5
+      env: TOXENV=py35-dj110-drf35-codecov
+    - python: 3.5
+      env: TOXENV=py35-dj110-drf36-codecov
 
-    # - python: 3.5
-    #   env: TOXENV=py35-dj111-drf34-codecov
-    # - python: 3.5
-    #   env: TOXENV=py35-dj111-drf35-codecov
-    # - python: 3.5
-    #   env: TOXENV=py35-dj111-drf36-codecov
+    - python: 3.5
+      env: TOXENV=py35-dj111-drf34-codecov
+    - python: 3.5
+      env: TOXENV=py35-dj111-drf35-codecov
+    - python: 3.5
+      env: TOXENV=py35-dj111-drf36-codecov
 
-    # - python: 3.6
-    #   env: TOXENV=py36-dj110-drf34-codecov
-    # - python: 3.6
-    #   env: TOXENV=py36-dj110-drf35-codecov
-    # - python: 3.6
-    #   env: TOXENV=py36-dj110-drf36-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj110-drf34-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj110-drf35-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj110-drf36-codecov
 
-    # - python: 3.6
-    #   env: TOXENV=py36-dj111-drf34-codecov
-    # - python: 3.6
-    #   env: TOXENV=py36-dj111-drf35-codecov
-    # - python: 3.6
-    #   env: TOXENV=py36-dj111-drf36-codecov
-    # - python: 3.6
-    #   env: TOXENV=py36-dj111-drf37-codecov
-    # - python: 3.6
-    #   env: TOXENV=py36-dj111-drf38-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj111-drf34-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj111-drf35-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj111-drf36-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj111-drf37-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj111-drf38-codecov
 
 
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,23 @@ matrix:
       env: TOXENV=py36-dj111-drf35-codecov
     - python: 3.6
       env: TOXENV=py36-dj111-drf36-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj111-drf37-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj111-drf38-codecov
+
+
+    - python: 3.6
+      env: TOXENV=py36-dj20-drf34-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj20-drf35-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj20-drf36-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj20-drf37-codecov
+    - python: 3.6
+      env: TOXENV=py36-dj20-drf38-codecov
+
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,19 +50,6 @@ matrix:
     - python: 2.7
       env: TOXENV=py27-dj111-drf36-codecov
 
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf31-codecov
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf32-codecov
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf33-codecov
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf34-codecov
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf35-codecov
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf36-codecov
-
     - python: 3.4
       env: TOXENV=py34-dj18-drf31-codecov
     - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,143 +5,137 @@ cache: pip
 matrix:
   fast_finish: true
   include:
-    - python: 2.7
-      env: TOXENV=py27-flake8
-    - python: 2.7
-      env: TOXENV=py27-docs
+    # - python: 2.7
+    #   env: TOXENV=py27-flake8
+    # - python: 2.7
+    #   env: TOXENV=py27-docs
 
-    - python: 2.7
-      env: TOXENV=py27-dj18-drf31-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj18-drf32-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj18-drf33-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj18-drf34-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj18-drf35-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj18-drf36-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj18-drf31-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj18-drf32-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj18-drf33-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj18-drf34-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj18-drf35-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj18-drf36-codecov
 
-    - python: 2.7
-      env: TOXENV=py27-dj19-drf31-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj19-drf32-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj19-drf33-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj19-drf34-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj19-drf35-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj19-drf36-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj19-drf31-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj19-drf32-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj19-drf33-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj19-drf34-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj19-drf35-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj19-drf36-codecov
 
-    - python: 2.7
-      env: TOXENV=py27-dj110-drf34-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj110-drf35-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj110-drf36-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj110-drf34-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj110-drf35-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj110-drf36-codecov
 
-    - python: 2.7
-      env: TOXENV=py27-dj111-drf34-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj111-drf35-codecov
-    - python: 2.7
-      env: TOXENV=py27-dj111-drf36-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj111-drf34-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj111-drf35-codecov
+    # - python: 2.7
+    #   env: TOXENV=py27-dj111-drf36-codecov
 
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf31-codecov
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf32-codecov
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf33-codecov
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf34-codecov
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf35-codecov
-    - python: 3.3
-      env: TOXENV=py33-dj18-drf36-codecov
+    # - python: 3.3
+    #   env: TOXENV=py33-dj18-drf31-codecov
+    # - python: 3.3
+    #   env: TOXENV=py33-dj18-drf32-codecov
+    # - python: 3.3
+    #   env: TOXENV=py33-dj18-drf33-codecov
+    # - python: 3.3
+    #   env: TOXENV=py33-dj18-drf34-codecov
+    # - python: 3.3
+    #   env: TOXENV=py33-dj18-drf35-codecov
+    # - python: 3.3
+    #   env: TOXENV=py33-dj18-drf36-codecov
 
-    - python: 3.4
-      env: TOXENV=py34-dj18-drf31-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj18-drf32-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj18-drf33-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj18-drf34-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj18-drf35-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj18-drf36-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj18-drf31-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj18-drf32-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj18-drf33-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj18-drf34-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj18-drf35-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj18-drf36-codecov
 
-    - python: 3.4
-      env: TOXENV=py34-dj19-drf31-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj19-drf32-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj19-drf33-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj19-drf34-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj19-drf35-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj19-drf36-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj19-drf31-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj19-drf32-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj19-drf33-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj19-drf34-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj19-drf35-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj19-drf36-codecov
 
-    - python: 3.4
-      env: TOXENV=py34-dj110-drf34-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj110-drf35-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj110-drf36-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj110-drf34-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj110-drf35-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj110-drf36-codecov
 
-    - python: 3.4
-      env: TOXENV=py34-dj111-drf34-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj111-drf35-codecov
-    - python: 3.4
-      env: TOXENV=py34-dj111-drf36-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj111-drf34-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj111-drf35-codecov
+    # - python: 3.4
+    #   env: TOXENV=py34-dj111-drf36-codecov
 
-    - python: 3.5
-      env: TOXENV=py35-dj110-drf34-codecov
-    - python: 3.5
-      env: TOXENV=py35-dj110-drf35-codecov
-    - python: 3.5
-      env: TOXENV=py35-dj110-drf36-codecov
+    # - python: 3.5
+    #   env: TOXENV=py35-dj110-drf34-codecov
+    # - python: 3.5
+    #   env: TOXENV=py35-dj110-drf35-codecov
+    # - python: 3.5
+    #   env: TOXENV=py35-dj110-drf36-codecov
 
-    - python: 3.5
-      env: TOXENV=py35-dj111-drf34-codecov
-    - python: 3.5
-      env: TOXENV=py35-dj111-drf35-codecov
-    - python: 3.5
-      env: TOXENV=py35-dj111-drf36-codecov
+    # - python: 3.5
+    #   env: TOXENV=py35-dj111-drf34-codecov
+    # - python: 3.5
+    #   env: TOXENV=py35-dj111-drf35-codecov
+    # - python: 3.5
+    #   env: TOXENV=py35-dj111-drf36-codecov
 
-    - python: 3.6
-      env: TOXENV=py36-dj110-drf34-codecov
-    - python: 3.6
-      env: TOXENV=py36-dj110-drf35-codecov
-    - python: 3.6
-      env: TOXENV=py36-dj110-drf36-codecov
+    # - python: 3.6
+    #   env: TOXENV=py36-dj110-drf34-codecov
+    # - python: 3.6
+    #   env: TOXENV=py36-dj110-drf35-codecov
+    # - python: 3.6
+    #   env: TOXENV=py36-dj110-drf36-codecov
 
-    - python: 3.6
-      env: TOXENV=py36-dj111-drf34-codecov
-    - python: 3.6
-      env: TOXENV=py36-dj111-drf35-codecov
-    - python: 3.6
-      env: TOXENV=py36-dj111-drf36-codecov
-    - python: 3.6
-      env: TOXENV=py36-dj111-drf37-codecov
-    - python: 3.6
-      env: TOXENV=py36-dj111-drf38-codecov
+    # - python: 3.6
+    #   env: TOXENV=py36-dj111-drf34-codecov
+    # - python: 3.6
+    #   env: TOXENV=py36-dj111-drf35-codecov
+    # - python: 3.6
+    #   env: TOXENV=py36-dj111-drf36-codecov
+    # - python: 3.6
+    #   env: TOXENV=py36-dj111-drf37-codecov
+    # - python: 3.6
+    #   env: TOXENV=py36-dj111-drf38-codecov
 
 
-    - python: 3.6
-      env: TOXENV=py36-dj20-drf34-codecov
-    - python: 3.6
-      env: TOXENV=py36-dj20-drf35-codecov
-    - python: 3.6
-      env: TOXENV=py36-dj20-drf36-codecov
     - python: 3.6
       env: TOXENV=py36-dj20-drf37-codecov
     - python: 3.6

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,10 @@ Requirements
 ------------
 
 -  Python (2.7, 3.3, 3.4, 3.5, 3.6)
--  Django (1.8, 1.9, 1.10, 1.11)
--  Django REST Framework (3.1, 3.2, 3.3, 3.4, 3.5, 3.6)
+-  Django (1.8, 1.9, 1.10, 1.11, 2.0\*)
+-  Django REST Framework (3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7\*, 3.8\*)
+
+\* Django 2.0 is tested only on Python 3.6 and Django REST Framework 3.7, 3.8
 
 Installation
 ------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,8 +28,10 @@ If you want to know more about JWT, check out the following resources:
 ## Requirements
 
 - Python (2.7, 3.3, 3.4, 3.5, 3.6)
-- Django (1.8, 1.9, 1.10)
-- Django REST Framework (3.0, 3.1, 3.2, 3.3, 3.4, 3.5)
+- Django (1.8, 1.9, 1.10, 1.11, 2.0\*)
+- Django REST Framework (3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7\*, 3.8\*)
+
+\* Django 2.0 is tested only on Python 3.6 and Django Rest Framework 3.7, 3.8
 
 ## Security
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -15,8 +15,8 @@ User = get_user_model()
 drf2 = rest_framework.VERSION < StrictVersion('3.0.0')
 drf3 = rest_framework.VERSION >= StrictVersion('3.0.0')
 
-django_version = StrictVersion('%s.%s.%s' % django.VERSION[:3])
-django2 = DJANGO_VERSION > StrictVersion('1.10.0')
+django_strict_version = StrictVersion('%s.%s.%s' % django.VERSION[:3])
+django2 = django_strict_version > StrictVersion('1.10.0')
 
 class JSONWebTokenSerializerTests(TestCase):
     def setUp(self):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -15,6 +15,8 @@ User = get_user_model()
 drf2 = rest_framework.VERSION < StrictVersion('3.0.0')
 drf3 = rest_framework.VERSION >= StrictVersion('3.0.0')
 
+django_version = StrictVersion('%s.%s.%s' % django.VERSION[:3])
+django2 = DJANGO_VERSION > StrictVersion('1.10.0')
 
 class JSONWebTokenSerializerTests(TestCase):
     def setUp(self):
@@ -71,7 +73,7 @@ class JSONWebTokenSerializerTests(TestCase):
         self.assertEqual(serializer.errors, expected_error)
 
     @unittest.skipIf(
-        django.VERSION[1] >= 10,
+        django2,
         reason='The ModelBackend does not permit login when is_active is False.')
     def test_disabled_user(self):
         self.user.is_active = False
@@ -88,7 +90,7 @@ class JSONWebTokenSerializerTests(TestCase):
         self.assertEqual(serializer.errors, expected_error)
 
     @unittest.skipUnless(
-        django.VERSION[1] >= 10,
+        django2,
         reason='The AllowAllUsersModelBackend permits login when is_active is False.')
     @override_settings(AUTHENTICATION_BACKENDS=[
         'django.contrib.auth.backends.AllowAllUsersModelBackend'])

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -18,6 +18,7 @@ drf3 = rest_framework.VERSION >= StrictVersion('3.0.0')
 django_strict_version = StrictVersion('%s.%s.%s' % django.VERSION[:3])
 django2 = django_strict_version > StrictVersion('1.10.0')
 
+
 class JSONWebTokenSerializerTests(TestCase):
     def setUp(self):
         self.email = 'jpueblo@example.com'

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34,py35,py36}-dj{18,19,110,111}-drf{31,32,33,34,35,36}
+       {py27,py33,py34,py35,py36}-dj{18,19,110,111,20}-drf{31,32,33,34,35,36,37,38,39}
 
 [testenv]
 commands =
@@ -15,12 +15,15 @@ deps =
        dj19: Django<1.10
        dj110: Django<1.11
        dj111: Django<1.12
+       dj20: Django<2.1
        drf31: djangorestframework<3.2
        drf32: djangorestframework<3.3
        drf33: djangorestframework<3.4
        drf34: djangorestframework<3.5
        drf35: djangorestframework<3.6
        drf36: djangorestframework<3.7
+       drf37: djangorestframework<3.8
+       drf38: djangorestframework<3.9
        py27-dj{18,19}-drf{31,32,33,34}: djangorestframework-oauth==1.0.1
        -rrequirements/testing.txt
        coverage: coverage


### PR DESCRIPTION
Hello.

I updated the test skip in `test_serializers` as it was comparing the Django version to 1.10 by checking only the second digit, which fails for Django 2.0. I also updated the tox.ini, .travis.yml and the documentation accordingly.

I removed the 3.3 tests as it fails the test (can't create the virtualenv, the bug is found here: https://github.com/tox-dev/tox/issues/644).