### PR TITLE
Update ` request.user ` after authenticating.

### DIFF
--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -66,6 +66,7 @@ class JSONWebTokenAPIView(APIView):
                                     token,
                                     expires=expiration,
                                     httponly=True)
+            request.user = user
             return response
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
If we don't do this, then `request.user` will be the wrong instance after authenticating - which can lead to some weird issues. Specifically, in projects that use `request.user` in response middleware.