### PR TITLE
Fix attribute on documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -300,7 +300,7 @@ To achieve this functionality, the user might write a custom `Authentication`:
 ```python
 class JSONWebTokenAuthenticationQS(BaseJSONWebTokenAuthentication):
     def get_jwt_value(self, request):
-         return request.QUERY_PARAMS.get('jwt')
+         return request.query_params.get('jwt')
 ```
 It is recommended to use `BaseJSONWebTokenAuthentication`, a new base class with no logic around parsing the HTTP headers.
 


### PR DESCRIPTION
I was implementing the example and I received an error from Rest Framework.
They're using `query_params` instead of `QUERY_PARAMS`.
The old attribute in uppercase was removed.