### PR TITLE
Django 2.0 supprt 

### DIFF
--- a/requirements/optionals.txt
+++ b/requirements/optionals.txt
@@ -1,3 +1,3 @@
-oauth2==1.5.211
+oauth2==1.9.0.post1
 django-oauth-plus==2.2.6
 django-oauth2-provider==0.2.6.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,4 +1,4 @@
-pytest==2.6.4
-pytest-django==2.8.0
-pytest-cov==1.6
-cryptography==2.0.3
+pytest==4.4.1
+pytest-django==3.4.8
+pytest-cov==2.6.1
+cryptography==2.6.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def pytest_configure():
         pass
     else:
         settings.INSTALLED_APPS += (
-            'oauth_provider',
+            'oauth2_provider',
         )
 
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,10 +48,14 @@ def pytest_configure():
     except ImportError:
         pass
     else:
-        settings.INSTALLED_APPS += (
-            'oauth2_provider',
-        )
-
+        if django.VERSION[0] > 1:
+            settings.INSTALLED_APPS += (
+                'oauth2_provider',
+            )
+        else:
+            settings.INSTALLED_APPS += (
+                'oauth_provider',
+            )
     try:
         if django.VERSION >= (1, 8):
             # django-oauth2-provider does not support Django1.8

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -71,7 +71,7 @@ class JSONWebTokenSerializerTests(TestCase):
         self.assertEqual(serializer.errors, expected_error)
 
     @unittest.skipIf(
-        django.VERSION[1] >= 10,
+        django.VERSION[1] >= 1,
         reason='The ModelBackend does not permit login when is_active is False.')
     def test_disabled_user(self):
         self.user.is_active = False


### PR DESCRIPTION
I have changed package version to compatible with Django latest version. Also changed check for oauth2_provider import.

All existing test cases are running except for Python: 3.3 support.  getting this error `RuntimeError: Python 3.4 or later is required` for tox.  tox not working on 3.3 version.

#433
